### PR TITLE
feat: logout user

### DIFF
--- a/src/__tests__/auth/logout.controller.test.ts
+++ b/src/__tests__/auth/logout.controller.test.ts
@@ -1,0 +1,91 @@
+import { logoutUser } from "../../auth/auth.controller";
+import { RefreshToken } from "../../entities/refreshToken.entity";
+
+jest.mock("@src/datasource", () => {
+  const updateMock = jest.fn();
+  return {
+    __esModule: true,
+    default: {
+      manager: {
+        update: updateMock,
+      },
+    },
+    __mocks__: {
+      updateMock,
+    },
+  };
+});
+
+const { __mocks__ } = require("@src/datasource");
+const updateMock = __mocks__.updateMock;
+
+const mockResponse = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.clearCookie = jest.fn().mockReturnValue(res);
+  res.locals = {};
+  return res;
+};
+
+const mockNext = jest.fn();
+
+describe("AuthController - logoutUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should invalidate refresh token and clear cookie", async () => {
+    const req = {
+      cookies: {
+        refreshToken: "mocked_refresh_token",
+      },
+      secure: true,
+      headers: {},
+    } as any;
+
+    const res = mockResponse();
+
+    await logoutUser(req, res, mockNext);
+
+    expect(updateMock).toHaveBeenCalledWith(
+      RefreshToken,
+      { token: "mocked_refresh_token", is_valid: true },
+      { is_valid: false },
+    );
+
+    expect(res.clearCookie).toHaveBeenCalledWith("refresh_token", {
+      httpOnly: true,
+      secure: true,
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      status: "success",
+      message: "User logged out successfully",
+    });
+  });
+
+  it("should handle case where no refresh token is present", async () => {
+    const req = {
+      cookies: {},
+      secure: false,
+      headers: {},
+    } as any;
+
+    const res = mockResponse();
+
+    await logoutUser(req, res, mockNext);
+
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(res.clearCookie).toHaveBeenCalledWith("refresh_token", {
+      httpOnly: true,
+      secure: false,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      status: "success",
+      message: "User logged out successfully",
+    });
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,29 @@
+import AppDataSource from "@src/datasource";
+import { RefreshToken } from "@src/entities/refreshToken.entity";
+import asyncHandler from "@src/middlewares/asyncHandler";
+import { NextFunction, Request, Response } from "express";
+
+export const logoutUser = asyncHandler(
+  async (req: Request, res: Response, _next: NextFunction) => {
+    const entityManager = AppDataSource.manager;
+    const refreshToken = req.cookies["refreshToken"];
+
+    if (refreshToken) {
+      await entityManager.update(
+        RefreshToken,
+        { token: refreshToken, is_valid: true },
+        { is_valid: false },
+      );
+    }
+
+    res.clearCookie("refresh_token", {
+      httpOnly: true,
+      secure: req.secure || req.headers["x-forwarded-proto"] === "https",
+    });
+
+    return res.status(200).json({
+      status: "success",
+      message: "User logged out successfully",
+    });
+  },
+);

--- a/src/auth/auth.route.ts
+++ b/src/auth/auth.route.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import passport from "passport";
+import { logoutUser } from "./auth.controller";
 import { googleOAuth, googleOAuthCallback } from "./google/google.controller";
 import {
   linkedInOAuth,
@@ -21,5 +22,7 @@ router.get(
   passport.authenticate("linkedin", { session: false }),
   linkedInOAuthCallback,
 );
+
+router.post("/logout", logoutUser);
 
 export default router;

--- a/src/docs/auth.docs.ts
+++ b/src/docs/auth.docs.ts
@@ -144,3 +144,42 @@ export const linkedInOAuthCallback = `
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 `;
+
+export const logoutUser = `
+/**
+ * @swagger
+ * /api/v1/auth/logout:
+ *   post:
+ *     summary: Logout user and invalidate refresh token
+ *     tags: [Authentication]
+ *     description: Logs out the user by invalidating the current refresh token and clearing it from the HTTP-only cookie.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User logged out successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: User logged out successfully
+ *       401:
+ *         description: Unauthorized or missing token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+`;

--- a/src/utils/createSendToken.ts
+++ b/src/utils/createSendToken.ts
@@ -65,7 +65,7 @@ export const createSendToken = async (
 
   if (options.mode === "redirect") {
     res.locals.access_token = accessToken;
-    res.locals.refresh_token = refreshToken;
+    res.cookie("refresh_token", refreshToken, cookieOptions);
     return;
   }
 


### PR DESCRIPTION
- set refresh token in http-only cookie during OAuth redirect
- create, test, and document logout functionality