### PR TITLE
feat(talents): implement search talents endpoint with filters and sorting

### DIFF
--- a/config/swaggerConfig.ts
+++ b/config/swaggerConfig.ts
@@ -126,6 +126,41 @@ const swaggerDefinition: SwaggerDefinition = {
         description: "JWT refresh token",
         example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
       },
+      TalentProfilePreview: {
+        type: "object",
+        properties: {
+          id: { type: "string", example: "a1b2c3d4-uuid" },
+          first_name: { type: "string", example: "Jane" },
+          last_name: { type: "string", example: "Doe" },
+          avatar: {
+            type: "string",
+            nullable: true,
+            example: "https://example.com/avatar.png",
+          },
+          state: { type: "string", example: "Lagos" },
+          country: { type: "string", example: "Nigeria" },
+          linkedin_profile: {
+            type: "string",
+            nullable: true,
+            example: "https://linkedin.com/in/janedoe",
+          },
+          skills: {
+            type: "array",
+            items: { type: "string" },
+            example: ["Node.js", "React", "TypeScript"],
+          },
+          experience_level: {
+            type: "string",
+            enum: ["entry", "intermediate", "expert"],
+            example: "intermediate",
+          },
+          portfolio_url: {
+            type: "string",
+            nullable: true,
+            example: "https://janedoe.dev",
+          },
+        },
+      },
     },
   },
   security: [

--- a/src/docs/talents.docs.ts
+++ b/src/docs/talents.docs.ts
@@ -88,3 +88,124 @@ export const saveTalent = `
    *               status_code: 500
    */
 `;
+
+export const searchTalents = `
+  /**
+   * @swagger
+   * /api/v1/talents:
+   *   get:
+   *     summary: Search and filter talent profiles
+   *     tags: [Talents]
+   *     description: Retrieves a paginated list of talent profiles based on search query and filters.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: q
+   *         schema:
+   *           type: string
+   *         description: Full-text search on name or skills
+   *       - in: query
+   *         name: skills
+   *         schema:
+   *           type: string
+   *         description: Comma-separated list of skills
+   *         example: React,Node.js
+   *       - in: query
+   *         name: experience
+   *         schema:
+   *           type: string
+   *           enum: [entry, intermediate, expert]
+   *         description: Filter by experience level
+   *       - in: query
+   *         name: state
+   *         schema:
+   *           type: string
+   *         description: Filter by state
+   *       - in: query
+   *         name: country
+   *         schema:
+   *           type: string
+   *         description: Filter by country
+   *       - in: query
+   *         name: sort
+   *         schema:
+   *           type: string
+   *           enum: [recent, upvotes, experience]
+   *         description: Sort results by field
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 10
+   *         description: Number of results per page
+   *       - in: query
+   *         name: cursor
+   *         schema:
+   *           type: string
+   *         description: Pagination cursor (base64 encoded)
+   *       - in: query
+   *         name: direction
+   *         schema:
+   *           type: string
+   *           enum: [next, prev]
+   *         description: Pagination direction
+   *     responses:
+   *       200:
+   *         description: Talents fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: success
+   *                 message:
+   *                   type: string
+   *                   example: Talents fetched successfully
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     results:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/TalentProfilePreview'
+   *                     count:
+   *                       type: integer
+   *                     nextCursor:
+   *                       type: string
+   *                       nullable: true
+   *                     previousCursor:
+   *                       type: string
+   *                       nullable: true
+   *                     hasNextPage:
+   *                       type: boolean
+   *                     hasPreviousPage:
+   *                       type: boolean
+   *       401:
+   *         description: Unauthorized
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - Only recruiters can perform this action
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -10,6 +10,7 @@ import {
 } from "class-validator";
 import { Column, Entity, OneToMany, OneToOne } from "typeorm";
 import ExtendedBaseEntity from "./base.entity";
+import { MetricsEntity } from "./metrics.entity";
 import { NotificationEntity } from "./notification.entity";
 import { RecruiterProfileEntity } from "./recruiterProfile.entity";
 import { RefreshToken } from "./refreshToken.entity";
@@ -100,4 +101,7 @@ export class UserEntity extends ExtendedBaseEntity {
   )
   @Expose()
   received_notifications: NotificationEntity[];
+
+  @OneToOne(() => MetricsEntity, (m) => m.user)
+  metrics: MetricsEntity;
 }

--- a/src/talents/schemas/searchTalents.schema.ts
+++ b/src/talents/schemas/searchTalents.schema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const ExperienceLevelEnum = z.enum(["entry", "intermediate", "expert"]);
+
+export const searchTalentsSchema = z.object({
+  q: z.string().optional(),
+
+  skills: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((val) =>
+      typeof val === "string" ? val.split(",").map((s) => s.trim()) : val,
+    ),
+
+  experience: ExperienceLevelEnum.optional(),
+
+  state: z.string().optional(),
+  country: z.string().optional(),
+
+  sort: z.enum(["recent", "upvotes", "experience"]).optional(),
+
+  limit: z
+    .preprocess((val) => {
+      if (typeof val === "string" && /^[0-9]+$/.test(val)) {
+        return parseInt(val);
+      }
+      return val;
+    }, z.number().int().min(1).max(100))
+    .optional()
+    .default(10),
+
+  cursor: z
+    .string()
+    .regex(/^[a-zA-Z0-9+/=]+$/, { message: "Invalid cursor format" })
+    .optional(),
+
+  direction: z
+    .preprocess(
+      (val) => (typeof val === "string" ? val.toLowerCase() : val),
+      z.enum(["next", "prev"]),
+    )
+    .optional(),
+});
+
+export type SearchTalentsDto = z.infer<typeof searchTalentsSchema>;

--- a/src/talents/talent.controller.ts
+++ b/src/talents/talent.controller.ts
@@ -12,3 +12,15 @@ export const saveTalent = asyncHandler(async (req: Request, res: Response) => {
     .status(201)
     .json({ status: "success", message: "Talent saved successfully" });
 });
+
+export const searchTalents = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await talentService.searchTalents(req.query);
+
+    res.status(200).json({
+      status: "success",
+      message: "Talents fetched successfully",
+      data: result,
+    });
+  },
+);

--- a/src/talents/talent.route.ts
+++ b/src/talents/talent.route.ts
@@ -1,12 +1,17 @@
 import { UserRole } from "@src/entities/user.entity";
 import { checkRole } from "@src/middlewares/checkRole";
 import { deserializeUser } from "@src/middlewares/deserializeUser";
+import { validateData } from "@src/middlewares/validateData";
 import { Router } from "express";
-import { saveTalent } from "./talent.controller";
+import { searchTalentsSchema } from "./schemas/searchTalents.schema";
+import { saveTalent, searchTalents } from "./talent.controller";
 
 const router = Router();
 
 router.use(deserializeUser);
-router.post("/:id/save", checkRole(UserRole.RECRUITER), saveTalent);
+router.use(checkRole(UserRole.RECRUITER));
+
+router.post("/:id/save", saveTalent);
+router.get("/", validateData(searchTalentsSchema, ["query"]), searchTalents);
 
 export default router;

--- a/src/talents/talent.service.ts
+++ b/src/talents/talent.service.ts
@@ -3,16 +3,21 @@ import { NotificationService } from "@src/dashboard/services/notification.servic
 import AppDataSource from "@src/datasource";
 import { NotificationType } from "@src/entities/notification.entity";
 import { SavedTalentEntity } from "@src/entities/savedTalent.entity";
+import { TalentProfileEntity } from "@src/entities/talentProfile.entity";
 import { UserEntity } from "@src/entities/user.entity";
 import { ClientError } from "@src/exceptions/clientError";
 import { NotFoundError } from "@src/exceptions/notFoundError";
 import { CacheService } from "@src/utils/cache.service";
+import { SearchTalentsDto } from "./schemas/searchTalents.schema";
+import { decodeCursor, encodeCursor } from "./talent.utils";
 
 export class TalentService {
   private readonly userRepo = AppDataSource.getRepository(UserEntity);
   private readonly saveRepo = AppDataSource.getRepository(SavedTalentEntity);
   private readonly notificationService = new NotificationService();
   private readonly metricsService = new MetricsService();
+  private readonly profileRepo =
+    AppDataSource.getRepository(TalentProfileEntity);
 
   async saveTalent(talentId: string, recruiterId: string) {
     if (recruiterId === talentId) {
@@ -58,5 +63,104 @@ export class TalentService {
     await this.metricsService.incrementMetric(talentId, "recruiter_saves");
 
     await CacheService.del(`dashboard_talent_${recruiterId}`);
+  }
+
+  async searchTalents(query: SearchTalentsDto) {
+    const qb = this.profileRepo
+      .createQueryBuilder("talent")
+      .leftJoinAndSelect("talent.user", "user")
+      .leftJoinAndSelect("user.metrics", "metrics")
+      .where("user.profile_completed = true");
+
+    if (query.q) {
+      qb.andWhere(
+        "(user.first_name ILIKE :q OR user.last_name ILIKE :q OR EXISTS (SELECT 1 FROM unnest(talent.skills) s WHERE s ILIKE :q))",
+        { q: `%${query.q}%` },
+      );
+    }
+
+    if (query.skills?.length) {
+      qb.andWhere(
+        `EXISTS (SELECT 1 FROM unnest(talent.skills) s WHERE ${query.skills.map((_, i) => `s ILIKE :skill${i}`).join(" OR ")})`,
+        Object.fromEntries(query.skills.map((s, i) => [`skill${i}`, `%${s}%`])),
+      );
+    }
+
+    if (query.experience) {
+      qb.andWhere("talent.experience_level = :experience", {
+        experience: query.experience,
+      });
+    }
+
+    if (query.state) {
+      qb.andWhere("user.state ILIKE :state", { state: `%${query.state}%` });
+    }
+
+    if (query.country) {
+      qb.andWhere("user.country ILIKE :country", {
+        country: `%${query.country}%`,
+      });
+    }
+
+    switch (query.sort) {
+      case "upvotes":
+        qb.orderBy("metrics.upvotes", "DESC");
+        break;
+      case "experience":
+        qb.orderBy("talent.experience_level", "DESC");
+        break;
+      default:
+        qb.orderBy("user.created_at", "DESC").addOrderBy("user.id", "ASC");
+        break;
+    }
+
+    qb.take(query.limit);
+
+    if (query.cursor) {
+      const decoded = decodeCursor(query.cursor);
+      const direction = query.direction || "next";
+
+      if (decoded?.created_at && decoded?.id) {
+        const operator = direction === "next" ? ">" : "<";
+        qb.andWhere(
+          `(user.created_at, user.id) ${operator} (:created_at, :id)`,
+          {
+            created_at: decoded.created_at,
+            id: decoded.id,
+          },
+        );
+      }
+    }
+
+    const results = await qb.getMany();
+
+    const formatted = results.map((talent) => ({
+      id: talent.user.id,
+      first_name: talent.user.first_name,
+      last_name: talent.user.last_name,
+      avatar: talent.user.avatar,
+      state: talent.user.state,
+      country: talent.user.country,
+      linkedin_profile: talent.user.linkedin_profile,
+      skills: talent.skills,
+      experience_level: talent.experience_level,
+      portfolio_url: talent.portfolio_url,
+    }));
+
+    const last = results[results.length - 1];
+    const first = results[0];
+
+    return {
+      results: formatted,
+      count: results.length,
+      nextCursor: last
+        ? encodeCursor({ created_at: last.user.created_at, id: last.user.id })
+        : null,
+      previousCursor: first
+        ? encodeCursor({ created_at: first.user.created_at, id: first.user.id })
+        : null,
+      hasNextPage: results.length === query.limit,
+      hasPreviousPage: !!query.cursor,
+    };
   }
 }

--- a/src/talents/talent.utils.ts
+++ b/src/talents/talent.utils.ts
@@ -1,0 +1,11 @@
+export const encodeCursor = (cursor: Record<string, any>): string => {
+  return Buffer.from(JSON.stringify(cursor)).toString("base64");
+};
+
+export const decodeCursor = (encoded: string): Record<string, any> | null => {
+  try {
+    return JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
- Added GET /api/v1/talents route for recruiters
- Supports search by name, skills, state, country, experience
- Implements sorting by recency, upvotes, and experience level
- Applies cursor-based pagination with encoded cursors