### PR TITLE
feat(users, talents): implement profile editing and top talents endpoint with schema, migration, tests, and docs

### DIFF
--- a/src/__tests__/users/users.service.test.ts
+++ b/src/__tests__/users/users.service.test.ts
@@ -1,12 +1,18 @@
 import AppDataSource from "../../datasource";
-import { UserEntity } from "../../entities/user.entity";
+import { UserEntity, UserRole } from "../../entities/user.entity";
 import { NotFoundError } from "../../exceptions/notFoundError";
 import { UserService } from "../../users/users.service";
+import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 
 jest.mock("@src/datasource", () => ({
   __esModule: true,
   default: {
     getRepository: jest.fn(),
+    manager: {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    },
+    resolveAssetUrl: jest.fn((path) => `http://localhost:8000/${path}`),
   },
 }));
 
@@ -15,6 +21,7 @@ const mockRepo = {
 };
 
 (AppDataSource.getRepository as jest.Mock).mockReturnValue(mockRepo);
+const mockManager = AppDataSource.manager;
 
 describe("UserService", () => {
   const service = new UserService();
@@ -39,6 +46,68 @@ describe("UserService", () => {
     it("should throw NotFoundError if user not found", async () => {
       mockRepo.findOne.mockResolvedValue(null);
       await expect(service.getCurrentUser("1")).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("updateProfile", () => {
+    it("should update user profile successfully", async () => {
+      const mockUser = {
+        id: "1",
+        first_name: "Jane",
+        last_name: "Doe",
+        avatar: "old-avatar.png",
+        role: UserRole.TALENT,
+        talent_profile: { bio: "Old bio" },
+      } as UserEntity;
+
+      (mockManager.findOne as jest.Mock).mockResolvedValue(mockUser);
+
+      const payload = {
+        first_name: "John",
+        last_name: "Smith",
+        avatar: "new-avatar.png",
+        bio: "Updated bio",
+      };
+
+      const result = await service.updateProfile(
+        mockUser.id,
+        mockUser.role,
+        payload,
+      );
+
+      expect(mockManager.findOne).toHaveBeenCalledWith(UserEntity, {
+        where: { id: mockUser.id },
+        relations: ["talent_profile", "recruiter_profile"],
+      });
+
+      expect(mockUser.first_name).toBe("John");
+      expect(mockUser.last_name).toBe("Smith");
+      expect(mockUser.avatar).toBe("new-avatar.png");
+      expect(mockUser.talent_profile.bio).toBe("Updated bio");
+
+      expect(mockManager.save).toHaveBeenCalledWith(mockUser);
+      expect(mockManager.save).toHaveBeenCalledWith(mockUser.talent_profile);
+
+      expect(result).toEqual({
+        id: mockUser.id,
+        first_name: "John",
+        last_name: "Smith",
+        avatar: resolveAssetUrl("new-avatar.png"),
+        bio: "Updated bio",
+      });
+    });
+
+    it("should throw NotFoundError if user is not found", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.updateProfile("1", UserRole.TALENT, {
+          first_name: "John",
+          last_name: "Smith",
+          avatar: "new-avatar.png",
+          bio: "Updated bio",
+        }),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,6 +77,8 @@ app.use("/openapi.json", (_req: Request, res: Response) => {
 });
 
 app.use(`/${config.get<string>("API_PREFIX")}`, router);
+
+app.use("/uploads", express.static("uploads"));
 app.all("*", (req: Request, res: Response, next: NextFunction) => {
   if (res.headersSent) return next();
   if (

--- a/src/docs/talents.docs.ts
+++ b/src/docs/talents.docs.ts
@@ -523,3 +523,42 @@ export const getSavedTalents = `
    *               $ref: '#/components/schemas/ErrorResponse'
    */
 `;
+
+export const getTopTalents = `
+  /**
+   * @swagger
+   * /api/v1/talents/top:
+   *   get:
+   *     summary: Get top talent profiles for homepage
+   *     tags: [Talents]
+   *     description: Public endpoint to retrieve the top 10 talent profiles ranked by upvotes, recruiter saves, and profile views.
+   *     responses:
+   *       200:
+   *         description: Top talent profiles fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Top talents fetched successfully"
+   *                 data:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/TalentProfilePreview'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *             example:
+   *               status: "error"
+   *               message: "Something went wrong!"
+   *               status_code: 500
+   */
+`;

--- a/src/docs/users.docs.ts
+++ b/src/docs/users.docs.ts
@@ -56,3 +56,82 @@ export const getCurrentUser = `
  *               status_code: 500
  */
 `;
+
+export const updateUserProfile = `
+/**
+ * @swagger
+ * /api/v1/users/me:
+ *   patch:
+ *     summary: Update authenticated user's profile
+ *     tags: [Users]
+ *     description: Allows a user to update their first name, last name, avatar, and bio (for talents only).
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               first_name:
+ *                 type: string
+ *                 example: "Jane"
+ *               last_name:
+ *                 type: string
+ *                 example: "Doe"
+ *               bio:
+ *                 type: string
+ *                 example: "I am a full-stack developer"
+ *               avatar:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       200:
+ *         description: Profile updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "success"
+ *                 message:
+ *                   type: string
+ *                   example: "Profile updated successfully"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     first_name:
+ *                       type: string
+ *                     last_name:
+ *                       type: string
+ *                     avatar:
+ *                       type: string
+ *                     bio:
+ *                       type: string
+ *       401:
+ *         description: Unauthorized - No or invalid token provided
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               status: "error"
+ *               message: "Unauthorized"
+ *               status_code: 401
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               status: "error"
+ *               message: "Something went wrong!"
+ *               status_code: 500
+ */
+`;

--- a/src/entities/talentProfile.entity.ts
+++ b/src/entities/talentProfile.entity.ts
@@ -34,6 +34,12 @@ export class TalentProfileEntity extends ExtendedBaseEntity {
   @IsUrl()
   portfolio_url: string;
 
+  @Column({ type: "text", nullable: true })
+  @Expose()
+  @IsOptional()
+  @IsString()
+  bio?: string;
+
   @Column("text", { array: true })
   @Expose()
   @IsArray()

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -48,7 +48,7 @@ export class UserEntity extends ExtendedBaseEntity {
   @Column({ nullable: true })
   @Expose()
   @IsOptional()
-  @IsUrl()
+  @IsString()
   avatar: string;
 
   @Column({ type: "enum", enum: UserProvider })

--- a/src/middlewares/injectAvatarPath.ts
+++ b/src/middlewares/injectAvatarPath.ts
@@ -1,0 +1,12 @@
+import type { NextFunction, Request, Response } from "express";
+
+export const injectAvatarPath = (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  if (req.file && req.file.path) {
+    req.body.avatar = req.file.path;
+  }
+  next();
+};

--- a/src/middlewares/uploadAvatar.ts
+++ b/src/middlewares/uploadAvatar.ts
@@ -1,0 +1,9 @@
+import { createFileUploader } from "@src/utils/createFileUploader";
+
+const destinationFolder = process.env.UPLOADS_DIR || "uploads/avatars";
+
+export const uploadAvatar = createFileUploader({
+  destinationFolder,
+  fieldname: "avatar",
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+});

--- a/src/migrations/1748698044283-add-bio-to-talent-profile.ts
+++ b/src/migrations/1748698044283-add-bio-to-talent-profile.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddBioToTalentProfile1748698044283 implements MigrationInterface {
+  name = "AddBioToTalentProfile1748698044283";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_name = 'talent_profiles'
+          AND column_name = 'bio'
+        ) THEN
+          ALTER TABLE talent_profiles ADD COLUMN bio TEXT;
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE talent_profiles DROP COLUMN IF EXISTS bio;
+    `);
+  }
+}

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -49,6 +49,7 @@ export class OnboardingService {
         skills: p.skills,
         experience_level: p.experience_level as ExperienceLevel,
         profile_status: ProfileStatus.APPROVED,
+        bio: p.bio,
         skills_text: p.skills ? p.skills.join(" ") : "",
       });
       await manager.save(profile);

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -48,7 +48,7 @@ export class OnboardingService {
         portfolio_url: p.portfolio_url,
         skills: p.skills,
         experience_level: p.experience_level as ExperienceLevel,
-        profile_status: ProfileStatus.PENDING,
+        profile_status: ProfileStatus.APPROVED,
         skills_text: p.skills ? p.skills.join(" ") : "",
       });
       await manager.save(profile);

--- a/src/onboarding/schemas/talentOnboarding.schema.ts
+++ b/src/onboarding/schemas/talentOnboarding.schema.ts
@@ -23,6 +23,10 @@ export const talentOnboardingSchema = z.object({
   }),
 
   resume_path: z.string().min(1, "Resume upload failed"),
+  bio: z
+    .string()
+    .min(10, "Bio must be at least 10 characters")
+    .max(250, "Bio must not exceed 250 characters"),
 });
 
 export type TalentOnboardingDTO = z.infer<typeof talentOnboardingSchema>;

--- a/src/talents/talent.controller.ts
+++ b/src/talents/talent.controller.ts
@@ -66,3 +66,14 @@ export const getSavedTalents = asyncHandler(
     });
   },
 );
+
+export const getTopTalents = asyncHandler(
+  async (_req: Request, res: Response) => {
+    const result = await talentService.getTopTalents(10);
+    res.status(200).json({
+      status: "success",
+      message: "Top talents fetched successfully",
+      data: result,
+    });
+  },
+);

--- a/src/talents/talent.route.ts
+++ b/src/talents/talent.route.ts
@@ -7,12 +7,15 @@ import { searchTalentsSchema } from "./schemas/searchTalents.schema";
 import {
   getSavedTalents,
   getTalentById,
+  getTopTalents,
   saveTalent,
   searchTalents,
   toggleUpvoteTalent,
 } from "./talent.controller";
 
 const router = Router();
+
+router.get("/top", getTopTalents);
 
 router.use(deserializeUser);
 router.use(checkRole(UserRole.RECRUITER));

--- a/src/talents/utils/talent.utils.ts
+++ b/src/talents/utils/talent.utils.ts
@@ -179,7 +179,7 @@ export const formatTalentResult = (
     user = input as UserEntity;
     profile = user.talent_profile;
     metrics = user.metrics;
-    resume_path = profile.resume_path;
+    resume_path = profile?.resume_path ?? "";
     recruiter_saves = metrics?.recruiter_saves ?? 0;
   }
 

--- a/src/users/schemas/updateProfile.schema.ts
+++ b/src/users/schemas/updateProfile.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const updateProfileSchema = z.object({
+  first_name: z.string().min(1).max(50),
+  last_name: z.string().min(1).max(50),
+  bio: z.string().max(250).optional(),
+  avatar: z.string().optional(),
+});
+
+export type UpdateProfileDTO = z.infer<typeof updateProfileSchema>;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,5 +1,6 @@
 import asyncHandler from "@src/middlewares/asyncHandler";
 import { NextFunction, Request, Response } from "express";
+import { UpdateProfileDTO } from "./schemas/updateProfile.schema";
 import { UserService } from "./users.service";
 
 const userService = new UserService();
@@ -11,6 +12,21 @@ export const getCurrentUser = asyncHandler(
       status: "success",
       message: "User fetched successfully",
       data: { user },
+    });
+  },
+);
+
+export const updateProfile = asyncHandler(
+  async (req: Request, res: Response) => {
+    const user = req.user!;
+    const data = req.body as UpdateProfileDTO & { avatar?: string };
+
+    const updated = await userService.updateProfile(user.id, user.role, data);
+
+    res.status(200).json({
+      status: "success",
+      message: "Profile updated successfully",
+      data: updated,
     });
   },
 );

--- a/src/users/users.route.ts
+++ b/src/users/users.route.ts
@@ -1,9 +1,21 @@
 import { deserializeUser } from "@src/middlewares/deserializeUser";
+import { injectAvatarPath } from "@src/middlewares/injectAvatarPath";
+import { uploadAvatar } from "@src/middlewares/uploadAvatar";
+import { validateData } from "@src/middlewares/validateData";
 import { Router } from "express";
-import { getCurrentUser } from "./users.controller";
+import { updateProfileSchema } from "./schemas/updateProfile.schema";
+import { getCurrentUser, updateProfile } from "./users.controller";
 
 const router = Router();
 
 router.get("/me", deserializeUser, getCurrentUser);
+router.patch(
+  "/me",
+  deserializeUser,
+  uploadAvatar,
+  injectAvatarPath,
+  validateData(updateProfileSchema, ["body"]),
+  updateProfile,
+);
 
 export default router;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -2,6 +2,7 @@ import { DashboardService } from "@src/dashboard/services/dashboard.service";
 import AppDataSource from "@src/datasource";
 import { UserEntity, UserRole } from "@src/entities/user.entity";
 import { NotFoundError } from "@src/exceptions/notFoundError";
+import { resolveAssetUrl } from "@src/utils/resolveAssetUrl";
 import { sanitizeUser } from "@src/utils/sanitizeUser";
 import { UpdateProfileDTO } from "./schemas/updateProfile.schema";
 
@@ -62,7 +63,7 @@ export class UserService {
       id: user.id,
       first_name: user.first_name,
       last_name: user.last_name,
-      avatar: user.avatar,
+      avatar: resolveAssetUrl(user.avatar),
       bio: user.talent_profile?.bio,
     };
   }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,6 +3,7 @@ import AppDataSource from "@src/datasource";
 import { UserEntity, UserRole } from "@src/entities/user.entity";
 import { NotFoundError } from "@src/exceptions/notFoundError";
 import { sanitizeUser } from "@src/utils/sanitizeUser";
+import { UpdateProfileDTO } from "./schemas/updateProfile.schema";
 
 export class UserService {
   private userRepo = AppDataSource.getRepository(UserEntity);
@@ -29,6 +30,40 @@ export class UserService {
     return {
       ...sanitized,
       dashboard: dashboardData,
+    };
+  }
+
+  async updateProfile(
+    userId: string,
+    role: UserRole,
+    payload: UpdateProfileDTO,
+  ) {
+    const manager = AppDataSource.manager;
+
+    const user = await manager.findOne(UserEntity, {
+      where: { id: userId },
+      relations: ["talent_profile", "recruiter_profile"],
+    });
+
+    if (!user) throw new NotFoundError("User not found");
+
+    user.first_name = payload.first_name;
+    user.last_name = payload.last_name;
+    if (payload.avatar) user.avatar = payload.avatar;
+
+    await manager.save(user);
+
+    if (role === UserRole.TALENT && payload.bio) {
+      user.talent_profile.bio = payload.bio;
+      await manager.save(user.talent_profile);
+    }
+
+    return {
+      id: user.id,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      avatar: user.avatar,
+      bio: user.talent_profile?.bio,
     };
   }
 }

--- a/src/utils/resolveAssetUrl.ts
+++ b/src/utils/resolveAssetUrl.ts
@@ -1,0 +1,11 @@
+const BASE_URL = process.env.BASE_URL || "http://localhost:8000";
+
+export const resolveAssetUrl = (path?: string): string | null => {
+  if (!path) return null;
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  return `${BASE_URL}/${path}`;
+};

--- a/src/utils/sanitizeUser.ts
+++ b/src/utils/sanitizeUser.ts
@@ -1,11 +1,16 @@
 import { UserEntity } from "@src/entities/user.entity";
 import { instanceToPlain } from "class-transformer";
+import { resolveAssetUrl } from "./resolveAssetUrl";
 
 export const sanitizeUser = (user: UserEntity): Record<string, any> => {
   const plainUser = instanceToPlain(user, {
     strategy: "excludeAll",
     exposeUnsetFields: false,
   });
+
+  if (plainUser.avatar) {
+    plainUser.avatar = resolveAssetUrl(plainUser.avatar);
+  }
 
   const roleProfileMap: Record<string, any | undefined> = {
     talent: user.talent_profile,
@@ -14,13 +19,24 @@ export const sanitizeUser = (user: UserEntity): Record<string, any> => {
 
   const rawProfile = roleProfileMap[user.role ?? ""];
 
+  const plainProfile = rawProfile
+    ? instanceToPlain(rawProfile, {
+        strategy: "excludeAll",
+        exposeUnsetFields: false,
+      })
+    : undefined;
+
+  if (plainProfile && user.role === "talent") {
+    if (plainProfile.resume_path) {
+      plainProfile.resume_path = resolveAssetUrl(plainProfile.resume_path);
+    }
+    if (plainProfile.portfolio_url) {
+      plainProfile.portfolio_url = resolveAssetUrl(plainProfile.portfolio_url);
+    }
+  }
+
   return {
     ...plainUser,
-    profile: rawProfile
-      ? instanceToPlain(rawProfile, {
-          strategy: "excludeAll",
-          exposeUnsetFields: false,
-        })
-      : undefined,
+    profile: plainProfile,
   };
 };


### PR DESCRIPTION
This PR introduces several enhancements to user profile management and talent discovery features:

---

### 🔧 1. Auto-Approve Talent Profiles
- Updated the onboarding logic to set `profile_status` to `APPROVED` by default for all talents.
- This removes the manual approval flow, ensuring talents are immediately visible to recruiters post-onboarding.

---

### 📝 2. Add `bio` Field to Talent Profile
- Introduced `bio` to:
  - `talentOnboardingSchema`
  - `TalentProfileEntity`
  - `onboardUser()` in `OnboardingService`
- Created a TypeORM migration: `add-bio-to-talent-profile`
- `sanitizeUser()` updated to return full URLs for `resume_path`, `portfolio_url`, and `avatar`

---

### ✏️ 3. Edit Profile Functionality
- Users can now update `first_name`, `last_name`, `avatar` (as an image), and `bio` (for talents).
- Endpoint: `PATCH /api/v1/users/me` using `multipart/form-data`
- Avatar uploads handled via `uploadAvatar` middleware
- Profile updates are persisted in both `UserEntity` and `TalentProfileEntity`
- Added full unit tests for `UserService.updateProfile()`

---

### 🌟 4. Top Talents Endpoint for Homepage
- New endpoint: `GET /api/v1/talents/top`
- Public access (no auth required)
- Returns top 10 approved and completed talent profiles ranked by:
  - `metrics.upvotes`
  - `metrics.recruiter_saves`
  - `metrics.profile_views`
- Swagger documentation added under `[Talents]` tag
