### PR TITLE
feat(auth): implement local login with password verification

### DIFF
--- a/src/__tests__/auth/local/local.controller.test.ts
+++ b/src/__tests__/auth/local/local.controller.test.ts
@@ -1,6 +1,7 @@
 import * as controller from "../../../auth/local/local.controller";
 import { LocalAuthService } from "../../../auth/local/local.service";
 import { ConflictError } from "../../../exceptions/conflictError";
+import { UnauthorizedError } from "../../../exceptions/unauthorizedError";
 import { createSendToken } from "../../../utils/createSendToken";
 
 jest.mock("../../../utils/createSendToken", () => ({
@@ -109,6 +110,46 @@ describe("LocalAuthController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Invalid or expired OTP",
       });
+    });
+  });
+
+  describe("loginUser", () => {
+    it("should return tokens on successful login", async () => {
+      const email = "john.doe@example.com";
+      const password = "Password1!";
+      req = mockRequest({ email, password });
+
+      const mockUser = {
+        id: "user-123",
+        email,
+        is_email_verified: true,
+      } as any;
+      jest
+        .spyOn(LocalAuthService.prototype, "login")
+        .mockResolvedValueOnce(mockUser);
+
+      await controller.loginUser(req, res, mockNext);
+
+      expect(createSendToken).toHaveBeenCalledWith(
+        mockUser,
+        200,
+        "Login successful",
+        req,
+        res,
+        expect.any(Object),
+      );
+    });
+
+    it("should forward login errors to next", async () => {
+      req = mockRequest({ email: "test@example.com", password: "wrong" });
+      const error = new UnauthorizedError("Invalid email or password");
+      jest
+        .spyOn(LocalAuthService.prototype, "login")
+        .mockRejectedValueOnce(error);
+
+      await controller.loginUser(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/src/__tests__/auth/local/verifyEmail.test.ts
+++ b/src/__tests__/auth/local/verifyEmail.test.ts
@@ -1,13 +1,19 @@
 import { LocalAuthService } from "@src/auth/local/local.service";
 import { EmailOtpEntity } from "@src/entities/emailOtp.entity";
-import { UserEntity } from "@src/entities/user.entity";
+import { UserEntity, UserProvider } from "@src/entities/user.entity";
+import { UnauthorizedError } from "@src/exceptions/unauthorizedError";
 import { EmailService } from "@src/utils/email";
+import { verify } from "argon2";
 import { EntityManager } from "typeorm";
 
 jest.mock("@src/utils/email", () => ({
   EmailService: {
     sendVerification: jest.fn().mockResolvedValue({}),
   },
+}));
+
+jest.mock("argon2", () => ({
+  verify: jest.fn(),
 }));
 
 describe("LocalAuthService - Email Verification", () => {
@@ -147,6 +153,74 @@ describe("LocalAuthService - Email Verification", () => {
         mockManager as EntityManager,
       );
       expect(result).toBeNull();
+    });
+  });
+
+  describe("login", () => {
+    const email = "test@example.com";
+    const password = "Password1!";
+
+    it("should return user if credentials are valid", async () => {
+      const mockUser = {
+        id: "1",
+        email,
+        password: "hashedPassword",
+        provider: UserProvider.LOCAL,
+        is_email_verified: true,
+      } as UserEntity;
+
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce(mockUser);
+      (verify as jest.Mock).mockResolvedValueOnce(true);
+
+      const result = await authService.login(
+        { email, password },
+        mockManager as EntityManager,
+      );
+
+      expect(result).toEqual(mockUser);
+      expect(verify).toHaveBeenCalledWith("hashedPassword", password);
+    });
+
+    it("should throw UnauthorizedError if user not found", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce(null);
+
+      await expect(
+        authService.login({ email, password }, mockManager as EntityManager),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError if provider is not LOCAL", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce({
+        provider: UserProvider.GOOGLE,
+      });
+
+      await expect(
+        authService.login({ email, password }, mockManager as EntityManager),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError if email is not verified", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce({
+        provider: UserProvider.LOCAL,
+        is_email_verified: false,
+      });
+
+      await expect(
+        authService.login({ email, password }, mockManager as EntityManager),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    it("should throw UnauthorizedError if password is invalid", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce({
+        provider: UserProvider.LOCAL,
+        is_email_verified: true,
+        password: "hash",
+      });
+      (verify as jest.Mock).mockResolvedValueOnce(false);
+
+      await expect(
+        authService.login({ email, password }, mockManager as EntityManager),
+      ).rejects.toThrow(UnauthorizedError);
     });
   });
 });

--- a/src/auth/auth.route.ts
+++ b/src/auth/auth.route.ts
@@ -8,7 +8,8 @@ import {
   linkedInOAuth,
   linkedInOAuthCallback,
 } from "./linkedin/linkedin.controller";
-import { signupUser, verifyEmail } from "./local/local.controller";
+import { loginUser, signupUser, verifyEmail } from "./local/local.controller";
+import { loginSchema } from "./local/schemas/login.schema";
 import { signupSchema } from "./local/schemas/signup.schema";
 import { verifyEmailSchema } from "./local/schemas/verifyEmail.schema";
 
@@ -29,6 +30,8 @@ router.get(
 );
 
 router.post("/logout", logoutUser);
+
+router.post("/login", validateData(loginSchema), loginUser);
 
 router.post("/signup", validateData(signupSchema), asyncHandler(signupUser));
 

--- a/src/auth/local/local.controller.ts
+++ b/src/auth/local/local.controller.ts
@@ -3,6 +3,7 @@ import asyncHandler from "@src/middlewares/asyncHandler";
 import { createSendToken } from "@src/utils/createSendToken";
 import { NextFunction, Request, Response } from "express";
 import { LocalAuthService } from "./local.service";
+import type { LoginRequest } from "./schemas/login.schema";
 import type { LocalSignupRequest } from "./schemas/signup.schema";
 import type { VerifyEmailRequest } from "./schemas/verifyEmail.schema";
 
@@ -52,6 +53,26 @@ export const verifyEmail = asyncHandler(
       user,
       200,
       "Email verified Successfully",
+      req,
+      res,
+      AppDataSource.manager,
+    );
+  },
+);
+
+export const loginUser = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, password } = req.body as LoginRequest;
+
+    const user = await authService.login(
+      { email, password },
+      AppDataSource.manager,
+    );
+
+    await createSendToken(
+      user,
+      200,
+      "Login successful",
       req,
       res,
       AppDataSource.manager,

--- a/src/auth/local/local.service.ts
+++ b/src/auth/local/local.service.ts
@@ -1,12 +1,14 @@
 import { EmailOtpEntity } from "@src/entities/emailOtp.entity";
 import { UserEntity, UserProvider } from "@src/entities/user.entity";
 import { ConflictError } from "@src/exceptions/conflictError";
+import { UnauthorizedError } from "@src/exceptions/unauthorizedError";
 import { EmailService } from "@src/utils/email";
 import log from "@src/utils/logger";
 import { OtpUtil } from "@src/utils/otp.util";
-import { hash } from "argon2";
+import { hash, verify } from "argon2";
 import config from "config";
 import { EntityManager } from "typeorm";
+import type { LoginRequest } from "./schemas/login.schema";
 import type { LocalSignupDTO } from "./schemas/signup.schema";
 
 /**
@@ -107,5 +109,48 @@ export class LocalAuthService {
       await tx.save(record);
       return user;
     });
+  }
+
+  async login(
+    data: LoginRequest,
+    entityManager: EntityManager,
+  ): Promise<UserEntity> {
+    const { email, password } = data;
+
+    const user = await entityManager.findOne(UserEntity, {
+      where: { email },
+      // We need to select the password field explicitly since it's excluded by default for security reasons, but we need it here to verify the password. We also need to select provider and is_email_verified to enforce login rules.
+      select: [
+        "id",
+        "email",
+        "password",
+        "provider",
+        "is_email_verified",
+        "role",
+        "profile_completed",
+      ],
+    });
+
+    // Return custom error messages for better UX, but avoid leaking info about which part is incorrect
+    // This also prevents user enumeration attacks by not revealing whether the email exists or not
+    // This handles both non-existent users, users with incorrect passwords in the same way and Oauth users trying to log in with email/password as well as users who haven't verified their email yet.
+    if (!user || user.provider !== UserProvider.LOCAL) {
+      throw new UnauthorizedError("Invalid email or password");
+    }
+
+    // Users must verify their email before log in
+    if (!user.is_email_verified) {
+      throw new UnauthorizedError(
+        "Please verify your email address before logging in",
+      );
+    }
+
+    // Verify the password using argon2's verify function, which safely compares the hashed password with the provided one
+    const isValid = await verify(user.password!, password);
+    if (!isValid) {
+      throw new UnauthorizedError("Invalid email or password");
+    }
+
+    return user;
   }
 }

--- a/src/auth/local/schemas/login.schema.ts
+++ b/src/auth/local/schemas/login.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z
+    .string({ required_error: "required" })
+    .email("invalid")
+    .trim()
+    .toLowerCase(),
+  password: z.string({ required_error: "required" }).min(1, "required"),
+});
+
+export type LoginRequest = z.infer<typeof loginSchema>;

--- a/src/docs/auth.docs.ts
+++ b/src/docs/auth.docs.ts
@@ -280,3 +280,58 @@ export const localVerifyEmail = `
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 `;
+
+export const localLogin = `
+/**
+ * @swagger
+ * /api/v1/auth/login:
+ *   post:
+ *     summary: Login a local user
+ *     tags: [Authentication]
+ *     description: Authenticates a user with email and password, returning auth tokens.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: jane.doe@example.com
+ *               password:
+ *                 type: string
+ *                 example: Password1!
+ *             required:
+ *               - email
+ *               - password
+ *     responses:
+ *       200:
+ *         description: Login successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Login successful
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     access_token:
+ *                       $ref: '#/components/schemas/AccessToken'
+ *                     refresh_token:
+ *                       $ref: '#/components/schemas/RefreshToken'
+ *       401:
+ *         description: Invalid credentials or unverified email
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+`;


### PR DESCRIPTION
## Description

- Implement `login` method in `LocalAuthService` using argon2 for secure password verification.
- Add `loginUser` controller handler to manage the authentication flow and JWT issuance.
- Define `loginSchema` using Zod for request body validation with concise error messaging.
- Register the `POST /api/v1/auth/login` route in the authentication router.
- Add Swagger documentation for the login endpoint in `auth.docs.ts`.
- Include unit and controller tests covering successful login, invalid credentials, and unverified account scenarios.
