### PR TITLE
Feat/auth resend otp flow

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -4,6 +4,7 @@ export default {
   API_PREFIX: process.env.TALENTS_API_PREFIX ?? "api/v1",
   APP_NAME: process.env.TALENTS_APP_NAME ?? "Talent Board",
   OTP_TTL_MINUTES: Number(process.env.TALENTS_OTP_TTL_MINUTES) || 10,
+  OTP_RESEND_COOLDOWN_SECONDS: 60,
 
   DB_USER: process.env.TALENTS_DB_USER,
   DB_HOST: process.env.TALENTS_DB_HOST,

--- a/config/production.ts
+++ b/config/production.ts
@@ -4,6 +4,7 @@ export default {
   API_PREFIX: process.env.TALENTS_API_PREFIX ?? "api/v1",
   APP_NAME: process.env.TALENTS_APP_NAME ?? "Talent Board",
   OTP_TTL_MINUTES: Number(process.env.TALENTS_OTP_TTL_MINUTES) || 10,
+  OTP_RESEND_COOLDOWN_SECONDS: 60,
 
   DB_USER: process.env.TALENTS_DB_USER,
   DB_HOST: process.env.TALENTS_DB_HOST,

--- a/src/__tests__/auth/local/local.controller.test.ts
+++ b/src/__tests__/auth/local/local.controller.test.ts
@@ -1,6 +1,8 @@
 import * as controller from "../../../auth/local/local.controller";
 import { LocalAuthService } from "../../../auth/local/local.service";
+import { ClientError } from "../../../exceptions/clientError";
 import { ConflictError } from "../../../exceptions/conflictError";
+import { NotFoundError } from "../../../exceptions/notFoundError";
 import { createSendToken } from "../../../utils/createSendToken";
 
 jest.mock("../../../utils/createSendToken", () => ({
@@ -109,6 +111,66 @@ describe("LocalAuthController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Invalid or expired OTP",
       });
+    });
+  });
+
+  describe("resendOtp", () => {
+    const email = "test@example.com";
+
+    it("should return 200 on successful resend", async () => {
+      req = mockRequest({ email });
+      jest
+        .spyOn(LocalAuthService.prototype, "resendOtp")
+        .mockResolvedValueOnce();
+
+      await controller.resendOtp(req, res, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        status: "success",
+        message: expect.stringContaining("If an account exists"),
+      });
+    });
+
+    it("should return 200 even if user not found (anti-enumeration)", async () => {
+      req = mockRequest({ email: "missing@example.com" });
+      jest
+        .spyOn(LocalAuthService.prototype, "resendOtp")
+        .mockRejectedValueOnce(new NotFoundError("User not found"));
+
+      await controller.resendOtp(req, res, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        status: "success",
+        message: expect.stringContaining("If an account exists"),
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should return 200 for social login users (anti-enumeration)", async () => {
+      req = mockRequest({ email: "google-user@example.com" });
+      jest
+        .spyOn(LocalAuthService.prototype, "resendOtp")
+        .mockRejectedValueOnce(
+          new ClientError("This account uses social login"),
+        );
+
+      await controller.resendOtp(req, res, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should forward other errors (like cooldown) to next", async () => {
+      req = mockRequest({ email });
+      const cooldownError = new ClientError("Please wait 60 seconds");
+      jest
+        .spyOn(LocalAuthService.prototype, "resendOtp")
+        .mockRejectedValueOnce(cooldownError);
+
+      await controller.resendOtp(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(cooldownError);
     });
   });
 });

--- a/src/__tests__/auth/local/verifyEmail.test.ts
+++ b/src/__tests__/auth/local/verifyEmail.test.ts
@@ -1,9 +1,10 @@
 import { LocalAuthService } from "@src/auth/local/local.service";
 import { EmailOtpEntity } from "@src/entities/emailOtp.entity";
-import { UserEntity } from "@src/entities/user.entity";
+import { UserEntity, UserProvider } from "@src/entities/user.entity";
+import { ClientError } from "@src/exceptions/clientError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
 import { EmailService } from "@src/utils/email";
 import { EntityManager } from "typeorm";
-
 jest.mock("@src/utils/email", () => ({
   EmailService: {
     sendVerification: jest.fn().mockResolvedValue({}),
@@ -21,7 +22,7 @@ describe("LocalAuthService - Email Verification", () => {
       findOne: jest.fn(),
       save: jest.fn(),
       create: jest.fn().mockImplementation((entity, data) => data),
-      update: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
     jest.clearAllMocks();
   });
@@ -38,6 +39,11 @@ describe("LocalAuthService - Email Verification", () => {
         mockManager as EntityManager,
       );
 
+      expect(mockManager.update).toHaveBeenCalledWith(
+        EmailOtpEntity,
+        { email: "test@example.com", used_at: expect.anything() },
+        { expires_at: expect.any(Date) },
+      );
       expect(mockManager.create).toHaveBeenCalledWith(
         EmailOtpEntity,
         expect.objectContaining({
@@ -147,6 +153,86 @@ describe("LocalAuthService - Email Verification", () => {
         mockManager as EntityManager,
       );
       expect(result).toBeNull();
+    });
+  });
+
+  describe("resendOtp", () => {
+    const email = "test@example.com";
+
+    it("should successfully resend OTP if conditions are met", async () => {
+      const mockUser = {
+        email,
+        is_email_verified: false,
+        provider: UserProvider.LOCAL,
+      } as UserEntity;
+
+      (mockManager.findOne as jest.Mock)
+        .mockResolvedValueOnce(mockUser) // User find
+        .mockResolvedValueOnce(null); // lastOtp find (no cooldown)
+
+      const sendOtpSpy = jest
+        .spyOn(authService, "sendVerificationOtp")
+        .mockResolvedValueOnce();
+
+      await authService.resendOtp(email, mockManager as EntityManager);
+
+      expect(sendOtpSpy).toHaveBeenCalledWith(mockUser, mockManager);
+    });
+
+    it("should throw NotFoundError if user does not exist", async () => {
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce(null);
+
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw ClientError if user is already verified", async () => {
+      const mockUser = { email, is_email_verified: true } as UserEntity;
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce(mockUser);
+
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(ClientError);
+    });
+
+    it("should throw ClientError if user is not LOCAL provider", async () => {
+      const mockUser = {
+        email,
+        is_email_verified: false,
+        provider: UserProvider.GOOGLE,
+      } as UserEntity;
+      (mockManager.findOne as jest.Mock).mockResolvedValueOnce(mockUser);
+
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(ClientError);
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(/social login/);
+    });
+
+    it("should throw ClientError if within cooldown period", async () => {
+      const mockUser = {
+        email,
+        is_email_verified: false,
+        provider: UserProvider.LOCAL,
+      } as UserEntity;
+
+      const lastOtp = {
+        created_at: new Date(Date.now() - 30 * 1000), // 30 seconds ago
+      };
+
+      (mockManager.findOne as jest.Mock)
+        .mockResolvedValueOnce(mockUser) // User check
+        .mockResolvedValueOnce(lastOtp); // Cooldown check
+
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(ClientError);
+      await expect(
+        authService.resendOtp(email, mockManager as EntityManager),
+      ).rejects.toThrow(/Please wait/);
     });
   });
 });

--- a/src/auth/auth.route.ts
+++ b/src/auth/auth.route.ts
@@ -1,4 +1,3 @@
-import asyncHandler from "@src/middlewares/asyncHandler";
 import { validateData } from "@src/middlewares/validateData";
 import express from "express";
 import passport from "passport";
@@ -8,7 +7,8 @@ import {
   linkedInOAuth,
   linkedInOAuthCallback,
 } from "./linkedin/linkedin.controller";
-import { signupUser, verifyEmail } from "./local/local.controller";
+import { resendOtp, signupUser, verifyEmail } from "./local/local.controller";
+import { resendOtpSchema } from "./local/schemas/resendOtp.schema";
 import { signupSchema } from "./local/schemas/signup.schema";
 import { verifyEmailSchema } from "./local/schemas/verifyEmail.schema";
 
@@ -30,12 +30,10 @@ router.get(
 
 router.post("/logout", logoutUser);
 
-router.post("/signup", validateData(signupSchema), asyncHandler(signupUser));
+router.post("/signup", validateData(signupSchema), signupUser);
 
-router.post(
-  "/verify-email",
-  validateData(verifyEmailSchema),
-  asyncHandler(verifyEmail),
-);
+router.post("/verify-email", validateData(verifyEmailSchema), verifyEmail);
+
+router.post("/resend-otp", validateData(resendOtpSchema), resendOtp);
 
 export default router;

--- a/src/auth/local/local.controller.ts
+++ b/src/auth/local/local.controller.ts
@@ -1,8 +1,11 @@
 import AppDataSource from "@src/datasource";
+import { ClientError } from "@src/exceptions/clientError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
 import asyncHandler from "@src/middlewares/asyncHandler";
 import { createSendToken } from "@src/utils/createSendToken";
 import { NextFunction, Request, Response } from "express";
 import { LocalAuthService } from "./local.service";
+import type { ResendOtpRequest } from "./schemas/resendOtp.schema";
 import type { LocalSignupRequest } from "./schemas/signup.schema";
 import type { VerifyEmailRequest } from "./schemas/verifyEmail.schema";
 
@@ -56,5 +59,35 @@ export const verifyEmail = asyncHandler(
       res,
       AppDataSource.manager,
     );
+  },
+);
+
+export const resendOtp = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email } = req.body as ResendOtpRequest;
+
+    try {
+      await authService.resendOtp(email, AppDataSource.manager);
+    } catch (error) {
+      // Handle specific cases where OTP cannot be resent, but treat them as "success" for user experience
+      if (
+        error instanceof NotFoundError ||
+        (error instanceof ClientError && error.message.includes("social login"))
+      ) {
+        return res.status(200).json({
+          status: "success",
+          message:
+            "If an account exists for this email, a new verification code has been sent.",
+        });
+      }
+      console.error("Failed to resend verification OTP", error);
+      throw error;
+    }
+
+    return res.status(200).json({
+      status: "success",
+      message:
+        "If an account exists for this email, a new verification code has been sent.",
+    });
   },
 );

--- a/src/auth/local/local.service.ts
+++ b/src/auth/local/local.service.ts
@@ -1,12 +1,14 @@
 import { EmailOtpEntity } from "@src/entities/emailOtp.entity";
 import { UserEntity, UserProvider } from "@src/entities/user.entity";
+import { ClientError } from "@src/exceptions/clientError";
 import { ConflictError } from "@src/exceptions/conflictError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
 import { EmailService } from "@src/utils/email";
 import log from "@src/utils/logger";
 import { OtpUtil } from "@src/utils/otp.util";
 import { hash } from "argon2";
 import config from "config";
-import { EntityManager } from "typeorm";
+import { EntityManager, IsNull } from "typeorm";
 import type { LocalSignupDTO } from "./schemas/signup.schema";
 
 /**
@@ -66,7 +68,14 @@ export class LocalAuthService {
     entityManager: EntityManager,
     ttlMinutes = config.get<number>("OTP_TTL_MINUTES") || 10, // OTP validity duration
   ): Promise<void> {
-    // Invalidate any existing OTPs for this email
+    // Invalidate any existing unused OTPs for this email to ensure only the latest one is valid
+    await entityManager.update(
+      EmailOtpEntity,
+
+      { email: user.email, used_at: IsNull() },
+      { expires_at: new Date() },
+    );
+
     const otp = OtpUtil.generate(6);
     const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000);
 
@@ -93,12 +102,15 @@ export class LocalAuthService {
         order: { created_at: "DESC" },
       });
 
+      // Validation checks: record must exist, not be used, and should not be expired
       if (!record) return null;
       if (record.used_at) return null;
       if (record.expires_at < new Date()) return null;
 
       const user = await tx.findOne(UserEntity, { where: { email } });
-      if (!user) return null;
+
+      // Only allow verification for LOCAL users
+      if (!user || user.provider !== UserProvider.LOCAL) return null;
 
       user.is_email_verified = true;
       await tx.save(user);
@@ -107,5 +119,41 @@ export class LocalAuthService {
       await tx.save(record);
       return user;
     });
+  }
+
+  async resendOtp(email: string, entityManager: EntityManager): Promise<void> {
+    const cooldownSeconds =
+      config.get<number>("OTP_RESEND_COOLDOWN_SECONDS") || 60;
+    const user = await entityManager.findOne(UserEntity, { where: { email } });
+
+    if (!user) throw new NotFoundError("User not found");
+    if (user.is_email_verified)
+      throw new ClientError("Email is already verified");
+
+    // Only LOCAL users should have OTPs. If the user exists but isn't LOCAL,
+    if (user.provider !== UserProvider.LOCAL) {
+      throw new ClientError(
+        "This account uses social login and does not require verification.",
+      );
+    }
+
+    // Check for cooldown to prevent spamming
+    const lastOtp = await entityManager.findOne(EmailOtpEntity, {
+      where: { email },
+      order: { created_at: "DESC" },
+    });
+
+    if (lastOtp) {
+      // Calculate seconds since last OTP was created for cooldown enforcement
+      const secondsSinceLastOtp =
+        (Date.now() - lastOtp.created_at.getTime()) / 1000;
+      if (secondsSinceLastOtp < cooldownSeconds) {
+        throw new ClientError(
+          `Please wait ${Math.ceil(cooldownSeconds - secondsSinceLastOtp)} seconds before requesting a new code.`,
+        );
+      }
+    }
+
+    await this.sendVerificationOtp(user, entityManager);
   }
 }

--- a/src/auth/local/schemas/resendOtp.schema.ts
+++ b/src/auth/local/schemas/resendOtp.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const resendOtpSchema = z.object({
+  email: z
+    .string({ required_error: "Email is required" })
+    .email("Invalid email format")
+    .trim()
+    .toLowerCase(),
+});
+
+export type ResendOtpRequest = z.infer<typeof resendOtpSchema>;

--- a/src/docs/auth.docs.ts
+++ b/src/docs/auth.docs.ts
@@ -280,3 +280,47 @@ export const localVerifyEmail = `
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 `;
+
+export const localResendOtp = `
+/**
+ * @swagger
+ * /api/v1/auth/resend-otp:
+ *   post:
+ *     summary: Resend email verification OTP
+ *     tags: [Authentication]
+ *     description: Sends a new verification OTP to the user's email if the account exists and is not yet verified. Incorporates a cooldown period to prevent spam.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: jane.doe@example.com
+ *             required:
+ *               - email
+ *     responses:
+ *       200:
+ *         description: Success message (generic to prevent email enumeration)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: A new verification code has been sent.
+ *       400:
+ *         description: Cooldown active or email already verified
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+`;


### PR DESCRIPTION
## Description
This PR implements the end-to-end "Resend OTP" functionality for the local authentication provider and refactors the onboarding process to improve name validation and security. It incorporates industry-standard security practices, including anti-enumeration patterns and request cooldowns.

## Resend OTP Flow
Endpoint: Added POST /api/v1/auth/resend-otp with Zod validation.

Cooldown Protection: Implemented a 60-second cooldown (configurable via OTP_RESEND_COOLDOWN_SECONDS) to prevent spamming the email service.

Identity Protection: Implemented an anti-enumeration pattern in the controller; the API returns a generic success message even if the user is not found or uses social login (Google/LinkedIn).

Automatic Invalidation: Updated sendVerificationOtp to invalidate (expire) any previous unused OTPs for a user before generating a new one, ensuring only the most recent code is active.

Provider Guard: Restricts OTP resend and email verification to the local provider.