### PR TITLE
feat(messaging): add message request lifecycle APIs

### DIFF
--- a/config/swaggerConfig.ts
+++ b/config/swaggerConfig.ts
@@ -45,6 +45,10 @@ const swaggerDefinition: SwaggerDefinition = {
       name: "Onboarding",
       description: "Onboarding routes",
     },
+    {
+      name: "Messaging",
+      description: "Consent-gated message request routes",
+    },
   ],
   components: {
     securitySchemes: {

--- a/src/__tests__/messaging/messageRequest.service.test.ts
+++ b/src/__tests__/messaging/messageRequest.service.test.ts
@@ -1,0 +1,321 @@
+import AppDataSource from "@src/datasource";
+import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import {
+  MessageRequestEntity,
+  MessageRequestStatus,
+} from "@src/entities/messageRequest.entity";
+import { ProfileStatus } from "@src/entities/talentProfile.entity";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import { ClientError } from "@src/exceptions/clientError";
+import { ConflictError } from "@src/exceptions/conflictError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
+import { MessageRequestService } from "@src/messaging/services/messageRequest.service";
+import config from "config";
+
+jest.mock("@src/datasource", () => ({
+  __esModule: true,
+  default: {
+    getRepository: jest.fn(),
+  },
+}));
+
+jest.mock("config", () => ({
+  __esModule: true,
+  default: {
+    has: jest.fn(),
+    get: jest.fn(),
+  },
+}));
+
+const mockUserRepo = {
+  findOne: jest.fn(),
+};
+
+const mockRequestRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findAndCount: jest.fn(),
+  findOne: jest.fn(),
+};
+
+const mockThreadRepo = {
+  findOne: jest.fn(),
+};
+
+const now = new Date("2026-07-28T12:00:00.000Z");
+
+const recruiter = {
+  id: "11111111-1111-4111-8111-111111111111",
+  first_name: "Ada",
+  last_name: "Recruiter",
+  avatar: null,
+  role: UserRole.RECRUITER,
+} as UserEntity;
+
+const talent = {
+  id: "22222222-2222-4222-8222-222222222222",
+  first_name: "Tola",
+  last_name: "Talent",
+  avatar: "uploads/avatars/tola.png",
+  role: UserRole.TALENT,
+  profile_completed: true,
+  talent_profile: {
+    profile_status: ProfileStatus.APPROVED,
+  },
+} as UserEntity;
+
+const buildRequest = (
+  overrides: Partial<MessageRequestEntity> = {},
+): MessageRequestEntity =>
+  ({
+    id: "33333333-3333-4333-8333-333333333333",
+    intro_note: "We would like to chat.",
+    status: MessageRequestStatus.PENDING,
+    responded_at: null,
+    created_at: now,
+    updated_at: now,
+    recruiter,
+    talent,
+    ...overrides,
+  }) as MessageRequestEntity;
+
+const mockUsersFound = () => {
+  mockUserRepo.findOne.mockImplementation(({ where }) => {
+    if (where.role === UserRole.RECRUITER) return Promise.resolve(recruiter);
+    if (where.role === UserRole.TALENT) return Promise.resolve(talent);
+    return Promise.resolve(null);
+  });
+};
+
+const mockNoExistingRequestState = () => {
+  mockRequestRepo.findOne.mockResolvedValue(null);
+  mockThreadRepo.findOne.mockResolvedValue(null);
+};
+
+describe("MessageRequestService", () => {
+  let service: MessageRequestService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(now);
+    (config.has as jest.Mock).mockReturnValue(true);
+    (config.get as jest.Mock).mockReturnValue(30);
+
+    (AppDataSource.getRepository as jest.Mock).mockImplementation((entity) => {
+      if (entity === UserEntity) return mockUserRepo;
+      if (entity === MessageRequestEntity) return mockRequestRepo;
+      if (entity === ConversationThreadEntity) return mockThreadRepo;
+      return {};
+    });
+
+    service = new MessageRequestService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("createMessageRequest", () => {
+    it("creates a pending request with a normalized intro note", async () => {
+      mockUsersFound();
+      mockNoExistingRequestState();
+
+      const savedRequest = buildRequest({ intro_note: "Hello there" });
+      mockRequestRepo.create.mockImplementation((payload) => ({
+        ...payload,
+        id: savedRequest.id,
+        created_at: now,
+        updated_at: now,
+        responded_at: null,
+      }));
+      mockRequestRepo.save.mockResolvedValue(savedRequest);
+
+      const result = await service.createMessageRequest(recruiter.id, {
+        talent_id: talent.id,
+        intro_note: "  Hello there  ",
+      });
+
+      expect(mockRequestRepo.create).toHaveBeenCalledWith({
+        recruiter,
+        talent,
+        intro_note: "Hello there",
+        status: MessageRequestStatus.PENDING,
+      });
+      expect(mockRequestRepo.save).toHaveBeenCalled();
+      expect(result).toEqual({
+        id: savedRequest.id,
+        intro_note: "Hello there",
+        status: MessageRequestStatus.PENDING,
+        responded_at: null,
+        created_at: now,
+        updated_at: now,
+        recruiter: {
+          id: recruiter.id,
+          first_name: recruiter.first_name,
+          last_name: recruiter.last_name,
+          avatar: recruiter.avatar,
+          role: recruiter.role,
+        },
+        talent: {
+          id: talent.id,
+          first_name: talent.first_name,
+          last_name: talent.last_name,
+          avatar: talent.avatar,
+          role: talent.role,
+        },
+      });
+    });
+
+    it("rejects self-requests", async () => {
+      await expect(
+        service.createMessageRequest(recruiter.id, {
+          talent_id: recruiter.id,
+        }),
+      ).rejects.toThrow(ClientError);
+
+      expect(mockUserRepo.findOne).not.toHaveBeenCalled();
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing or unapproved talents", async () => {
+      mockUserRepo.findOne.mockImplementation(({ where }) => {
+        if (where.role === UserRole.RECRUITER)
+          return Promise.resolve(recruiter);
+        return Promise.resolve(null);
+      });
+
+      await expect(
+        service.createMessageRequest(recruiter.id, {
+          talent_id: talent.id,
+        }),
+      ).rejects.toThrow(NotFoundError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects duplicate pending requests", async () => {
+      mockUsersFound();
+      mockThreadRepo.findOne.mockResolvedValue(null);
+      mockRequestRepo.findOne.mockImplementation(({ where }) =>
+        Promise.resolve(
+          where.status === MessageRequestStatus.PENDING ? buildRequest() : null,
+        ),
+      );
+
+      await expect(
+        service.createMessageRequest(recruiter.id, {
+          talent_id: talent.id,
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects requests when a conversation already exists", async () => {
+      mockUsersFound();
+      mockRequestRepo.findOne.mockResolvedValue(null);
+      mockThreadRepo.findOne.mockResolvedValue({
+        id: "thread-id",
+      } as ConversationThreadEntity);
+
+      await expect(
+        service.createMessageRequest(recruiter.id, {
+          talent_id: talent.id,
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects declined requests still inside the cooldown window", async () => {
+      mockUsersFound();
+      mockThreadRepo.findOne.mockResolvedValue(null);
+      mockRequestRepo.findOne.mockImplementation(({ where }) =>
+        Promise.resolve(
+          where.status === MessageRequestStatus.DECLINED
+            ? buildRequest({
+                status: MessageRequestStatus.DECLINED,
+                responded_at: new Date("2026-07-10T12:00:00.000Z"),
+              })
+            : null,
+        ),
+      );
+
+      await expect(
+        service.createMessageRequest(recruiter.id, {
+          talent_id: talent.id,
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getIncomingRequests", () => {
+    it("lists requests for a talent and keeps personal email out of the response", async () => {
+      const request = buildRequest();
+      mockRequestRepo.findAndCount.mockResolvedValue([[request], 1]);
+
+      const result = await service.getIncomingRequests(talent.id, {
+        status: MessageRequestStatus.PENDING,
+        page: 1,
+        limit: 10,
+      });
+
+      expect(mockRequestRepo.findAndCount).toHaveBeenCalledWith({
+        where: {
+          talent: { id: talent.id },
+          status: MessageRequestStatus.PENDING,
+        },
+        relations: ["recruiter", "talent"],
+        order: { created_at: "DESC" },
+        skip: 0,
+        take: 10,
+      });
+      expect(result.requests[0].recruiter).not.toHaveProperty("email");
+      expect(result.requests[0].talent).not.toHaveProperty("email");
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
+  });
+
+  describe("getOutgoingRequests", () => {
+    it("lists requests for a recruiter", async () => {
+      const request = buildRequest({ status: MessageRequestStatus.DECLINED });
+      mockRequestRepo.findAndCount.mockResolvedValue([[request], 3]);
+
+      const result = await service.getOutgoingRequests(recruiter.id, {
+        status: MessageRequestStatus.DECLINED,
+        page: 2,
+        limit: 5,
+      });
+
+      expect(mockRequestRepo.findAndCount).toHaveBeenCalledWith({
+        where: {
+          recruiter: { id: recruiter.id },
+          status: MessageRequestStatus.DECLINED,
+        },
+        relations: ["recruiter", "talent"],
+        order: { created_at: "DESC" },
+        skip: 5,
+        take: 5,
+      });
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].status).toBe(MessageRequestStatus.DECLINED);
+      expect(result.pagination).toEqual({
+        page: 2,
+        limit: 5,
+        total: 3,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+    });
+  });
+});

--- a/src/docs/messaging.docs.ts
+++ b/src/docs/messaging.docs.ts
@@ -1,0 +1,340 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: Messaging
+ *     description: Consent-gated message request endpoints
+ *
+ * components:
+ *   schemas:
+ *     MessageRequestUserSummary:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *           example: "a1b2c3d4-1111-4222-8333-123456789abc"
+ *         first_name:
+ *           type: string
+ *           nullable: true
+ *           example: "Ada"
+ *         last_name:
+ *           type: string
+ *           nullable: true
+ *           example: "Lovelace"
+ *         avatar:
+ *           type: string
+ *           nullable: true
+ *           example: "uploads/avatars/ada.png"
+ *         role:
+ *           type: string
+ *           nullable: true
+ *           enum: [talent, recruiter]
+ *           example: "recruiter"
+ *     MessageRequest:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *           example: "b2c3d4e5-2222-4333-8444-123456789abc"
+ *         intro_note:
+ *           type: string
+ *           nullable: true
+ *           example: "We would like to schedule an interview with you."
+ *         status:
+ *           type: string
+ *           enum: [pending, accepted, declined]
+ *           example: "pending"
+ *         responded_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         created_at:
+ *           type: string
+ *           format: date-time
+ *         updated_at:
+ *           type: string
+ *           format: date-time
+ *         recruiter:
+ *           $ref: '#/components/schemas/MessageRequestUserSummary'
+ *         talent:
+ *           $ref: '#/components/schemas/MessageRequestUserSummary'
+ *     MessageRequestPagination:
+ *       type: object
+ *       properties:
+ *         page:
+ *           type: integer
+ *           example: 1
+ *         limit:
+ *           type: integer
+ *           example: 20
+ *         total:
+ *           type: integer
+ *           example: 42
+ *         totalPages:
+ *           type: integer
+ *           example: 3
+ *         hasNextPage:
+ *           type: boolean
+ *           example: true
+ *         hasPreviousPage:
+ *           type: boolean
+ *           example: false
+ */
+
+export const createMessageRequest = `
+  /**
+   * @swagger
+   * /api/v1/messages/requests:
+   *   post:
+   *     summary: Send a message request to a talent
+   *     tags: [Messaging]
+   *     description: Allows a recruiter to request permission to start a conversation with an approved talent profile. The full conversation does not unlock until the talent accepts.
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - talent_id
+   *             properties:
+   *               talent_id:
+   *                 type: string
+   *                 format: uuid
+   *                 description: ID of the talent receiving the request
+   *                 example: "a1b2c3d4-1111-4222-8333-123456789abc"
+   *               intro_note:
+   *                 type: string
+   *                 maxLength: 2000
+   *                 description: Optional introductory note from the recruiter
+   *                 example: "We would like to schedule an interview with you."
+   *     responses:
+   *       201:
+   *         description: Message request sent successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Message request sent successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     request:
+   *                       $ref: '#/components/schemas/MessageRequest'
+   *       400:
+   *         description: Bad request - recruiter attempted an invalid request such as messaging themselves
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only recruiters can send message requests
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       404:
+   *         description: Talent not found or not available for messaging
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       409:
+   *         description: Conflict - pending request, active conversation, or declined-request cooldown already applies
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const getIncomingMessageRequests = `
+  /**
+   * @swagger
+   * /api/v1/messages/requests/incoming:
+   *   get:
+   *     summary: List incoming message requests
+   *     tags: [Messaging]
+   *     description: Allows a talent to view message requests sent by recruiters. Personal email addresses are not included in the response.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *           enum: [pending, accepted, declined]
+   *         description: Optional request status filter
+   *       - in: query
+  *         name: page
+  *         schema:
+  *           type: integer
+  *           default: 1
+  *           minimum: 1
+  *         description: Page number to return
+  *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 20
+   *           minimum: 1
+   *           maximum: 100
+   *         description: Maximum number of requests to return
+   *     responses:
+   *       200:
+   *         description: Incoming message requests fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Incoming message requests fetched successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     requests:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/MessageRequest'
+  *                     pagination:
+  *                       $ref: '#/components/schemas/MessageRequestPagination'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only talents can view incoming message requests
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const getOutgoingMessageRequests = `
+  /**
+   * @swagger
+   * /api/v1/messages/requests/outgoing:
+   *   get:
+   *     summary: List outgoing message requests
+   *     tags: [Messaging]
+   *     description: Allows a recruiter to view message requests they have sent and their current Pending, Accepted, or Declined status.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *           enum: [pending, accepted, declined]
+   *         description: Optional request status filter
+   *       - in: query
+  *         name: page
+  *         schema:
+  *           type: integer
+  *           default: 1
+  *           minimum: 1
+  *         description: Page number to return
+  *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 20
+   *           minimum: 1
+   *           maximum: 100
+   *         description: Maximum number of requests to return
+   *     responses:
+   *       200:
+   *         description: Outgoing message requests fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Outgoing message requests fetched successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     requests:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/MessageRequest'
+  *                     pagination:
+  *                       $ref: '#/components/schemas/MessageRequestPagination'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only recruiters can view outgoing message requests
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -1,0 +1,51 @@
+import asyncHandler from "@src/middlewares/asyncHandler";
+import { Request, Response } from "express";
+import { ListMessageRequestsDto } from "./schemas/messageRequest.schema";
+import { MessageRequestService } from "./services/messageRequest.service";
+
+const messageRequestService = new MessageRequestService();
+
+export const createMessageRequest = asyncHandler(
+  async (req: Request, res: Response) => {
+    const request = await messageRequestService.createMessageRequest(
+      req.user.id,
+      req.body,
+    );
+
+    res.status(201).json({
+      status: "success",
+      message: "Message request sent successfully",
+      data: { request },
+    });
+  },
+);
+
+export const getIncomingMessageRequests = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await messageRequestService.getIncomingRequests(
+      req.user.id,
+      req.query as ListMessageRequestsDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Incoming message requests fetched successfully",
+      data: result,
+    });
+  },
+);
+
+export const getOutgoingMessageRequests = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await messageRequestService.getOutgoingRequests(
+      req.user.id,
+      req.query as ListMessageRequestsDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Outgoing message requests fetched successfully",
+      data: result,
+    });
+  },
+);

--- a/src/messaging/messaging.route.ts
+++ b/src/messaging/messaging.route.ts
@@ -1,0 +1,41 @@
+import { UserRole } from "@src/entities/user.entity";
+import { checkRole } from "@src/middlewares/checkRole";
+import { deserializeUser } from "@src/middlewares/deserializeUser";
+import { validateData } from "@src/middlewares/validateData";
+import { Router } from "express";
+import {
+  createMessageRequest,
+  getIncomingMessageRequests,
+  getOutgoingMessageRequests,
+} from "./messaging.controller";
+import {
+  createMessageRequestSchema,
+  listMessageRequestsSchema,
+} from "./schemas/messageRequest.schema";
+
+const router = Router();
+
+router.use(deserializeUser);
+
+router.post(
+  "/requests",
+  checkRole(UserRole.RECRUITER),
+  validateData(createMessageRequestSchema),
+  createMessageRequest,
+);
+
+router.get(
+  "/requests/incoming",
+  checkRole(UserRole.TALENT),
+  validateData(listMessageRequestsSchema, ["query"]),
+  getIncomingMessageRequests,
+);
+
+router.get(
+  "/requests/outgoing",
+  checkRole(UserRole.RECRUITER),
+  validateData(listMessageRequestsSchema, ["query"]),
+  getOutgoingMessageRequests,
+);
+
+export default router;

--- a/src/messaging/schemas/messageRequest.schema.ts
+++ b/src/messaging/schemas/messageRequest.schema.ts
@@ -1,0 +1,19 @@
+import { MessageRequestStatus } from "@src/entities/messageRequest.entity";
+import { z } from "zod";
+
+export const createMessageRequestSchema = z.object({
+  talent_id: z.string().uuid(),
+  intro_note: z.string().trim().max(2000).optional(),
+});
+
+export const listMessageRequestsSchema = z.object({
+  status: z.nativeEnum(MessageRequestStatus).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export type CreateMessageRequestDto = z.infer<
+  typeof createMessageRequestSchema
+>;
+
+export type ListMessageRequestsDto = z.infer<typeof listMessageRequestsSchema>;

--- a/src/messaging/services/messageRequest.service.ts
+++ b/src/messaging/services/messageRequest.service.ts
@@ -1,0 +1,297 @@
+import AppDataSource from "@src/datasource";
+import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import {
+  MessageRequestEntity,
+  MessageRequestStatus,
+} from "@src/entities/messageRequest.entity";
+import {
+  ProfileStatus,
+  TalentProfileEntity,
+} from "@src/entities/talentProfile.entity";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import { ClientError } from "@src/exceptions/clientError";
+import { ConflictError } from "@src/exceptions/conflictError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
+import config from "config";
+import {
+  CreateMessageRequestDto,
+  ListMessageRequestsDto,
+} from "../schemas/messageRequest.schema";
+
+interface MessageRequestUserSummary {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  avatar: string | null;
+  role: UserRole | null;
+}
+
+export interface MessageRequestSummary {
+  id: string;
+  intro_note: string | null;
+  status: MessageRequestStatus;
+  responded_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  recruiter: MessageRequestUserSummary;
+  talent: MessageRequestUserSummary;
+}
+
+export interface MessageRequestPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface PaginatedMessageRequestSummary {
+  requests: MessageRequestSummary[];
+  pagination: MessageRequestPagination;
+}
+
+export class MessageRequestService {
+  private readonly userRepo = AppDataSource.getRepository(UserEntity);
+  private readonly requestRepo =
+    AppDataSource.getRepository(MessageRequestEntity);
+  private readonly threadRepo = AppDataSource.getRepository(
+    ConversationThreadEntity,
+  );
+
+  async createMessageRequest(
+    recruiterId: string,
+    payload: CreateMessageRequestDto,
+  ): Promise<MessageRequestSummary> {
+    const talentId = payload.talent_id;
+
+    if (recruiterId === talentId) {
+      throw new ClientError("You cannot send a message request to yourself");
+    }
+
+    const [recruiter, talent] = await Promise.all([
+      this.userRepo.findOne({
+        where: { id: recruiterId, role: UserRole.RECRUITER },
+      }),
+      this.userRepo.findOne({
+        where: {
+          id: talentId,
+          role: UserRole.TALENT,
+          profile_completed: true,
+        },
+        relations: ["talent_profile"],
+      }),
+    ]);
+
+    if (!recruiter) {
+      throw new NotFoundError("Recruiter not found or unauthorized");
+    }
+
+    if (!this.isApprovedTalent(talent)) {
+      throw new NotFoundError("Talent not found");
+    }
+
+    await this.assertRequestCanBeCreated(recruiterId, talentId);
+
+    const messageRequest = this.requestRepo.create({
+      recruiter,
+      talent,
+      intro_note: this.normalizeIntroNote(payload.intro_note),
+      status: MessageRequestStatus.PENDING,
+    });
+
+    try {
+      const savedRequest = await this.requestRepo.save(messageRequest);
+      return this.formatMessageRequest(savedRequest);
+    } catch (error: any) {
+      if (error?.code === "23505") {
+        throw new ConflictError(
+          "A message request to this talent is already pending",
+        );
+      }
+      throw error;
+    }
+  }
+
+  async getIncomingRequests(
+    talentId: string,
+    query: ListMessageRequestsDto,
+  ): Promise<PaginatedMessageRequestSummary> {
+    const page = query.page ?? 1;
+    const limit = query.limit;
+    const skip = (page - 1) * limit;
+
+    const [requests, total] = await this.requestRepo.findAndCount({
+      where: {
+        talent: { id: talentId },
+        ...(query.status ? { status: query.status } : {}),
+      },
+      relations: ["recruiter", "talent"],
+      order: { created_at: "DESC" },
+      skip,
+      take: limit,
+    });
+
+    return {
+      requests: requests.map((request) => this.formatMessageRequest(request)),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+        hasNextPage: page * limit < total,
+        hasPreviousPage: page > 1,
+      },
+    };
+  }
+
+  async getOutgoingRequests(
+    recruiterId: string,
+    query: ListMessageRequestsDto,
+  ): Promise<PaginatedMessageRequestSummary> {
+    const page = query.page ?? 1;
+    const limit = query.limit;
+    const skip = (page - 1) * limit;
+
+    const [requests, total] = await this.requestRepo.findAndCount({
+      where: {
+        recruiter: { id: recruiterId },
+        ...(query.status ? { status: query.status } : {}),
+      },
+      relations: ["recruiter", "talent"],
+      order: { created_at: "DESC" },
+      skip,
+      take: limit,
+    });
+
+    return {
+      requests: requests.map((request) => this.formatMessageRequest(request)),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+        hasNextPage: page * limit < total,
+        hasPreviousPage: page > 1,
+      },
+    };
+  }
+
+  private async assertRequestCanBeCreated(
+    recruiterId: string,
+    talentId: string,
+  ): Promise<void> {
+    const [pendingRequest, acceptedRequest, existingThread, declinedRequest] =
+      await Promise.all([
+        this.requestRepo.findOne({
+          where: {
+            recruiter: { id: recruiterId },
+            talent: { id: talentId },
+            status: MessageRequestStatus.PENDING,
+          },
+        }),
+        this.requestRepo.findOne({
+          where: {
+            recruiter: { id: recruiterId },
+            talent: { id: talentId },
+            status: MessageRequestStatus.ACCEPTED,
+          },
+        }),
+        this.threadRepo.findOne({
+          where: {
+            recruiter: { id: recruiterId },
+            talent: { id: talentId },
+          },
+        }),
+        this.requestRepo.findOne({
+          where: {
+            recruiter: { id: recruiterId },
+            talent: { id: talentId },
+            status: MessageRequestStatus.DECLINED,
+          },
+          order: { responded_at: "DESC", updated_at: "DESC" },
+        }),
+      ]);
+
+    if (pendingRequest) {
+      throw new ConflictError(
+        "A message request to this talent is already pending",
+      );
+    }
+
+    if (acceptedRequest || existingThread) {
+      throw new ConflictError("A conversation with this talent already exists");
+    }
+
+    if (
+      declinedRequest &&
+      this.isWithinDeclineCooldownPeriod(declinedRequest)
+    ) {
+      throw new ConflictError(
+        "You cannot send another request to this talent yet",
+      );
+    }
+  }
+
+  private isApprovedTalent(user: UserEntity | null): user is UserEntity & {
+    talent_profile: TalentProfileEntity;
+  } {
+    return Boolean(
+      user?.role === UserRole.TALENT &&
+        user.profile_completed &&
+        user.talent_profile?.profile_status === ProfileStatus.APPROVED,
+    );
+  }
+
+  private isWithinDeclineCooldownPeriod(
+    request: MessageRequestEntity,
+  ): boolean {
+    const declinedAt =
+      request.responded_at || request.updated_at || request.created_at;
+    const cooldownEndsAt = new Date(
+      declinedAt.getTime() + this.declineCooldownDays * 24 * 60 * 60 * 1000,
+    );
+
+    return cooldownEndsAt > new Date();
+  }
+
+  private get declineCooldownDays(): number {
+    const configuredDays = config.has("MESSAGE_REQUEST_DECLINE_COOLDOWN_DAYS")
+      ? Number(config.get<number>("MESSAGE_REQUEST_DECLINE_COOLDOWN_DAYS"))
+      : 30;
+
+    return Number.isFinite(configuredDays) && configuredDays > 0
+      ? configuredDays
+      : 30;
+  }
+
+  private normalizeIntroNote(introNote?: string): string | null {
+    const normalized = introNote?.trim();
+    return normalized ? normalized : null;
+  }
+
+  private formatMessageRequest(
+    request: MessageRequestEntity,
+  ): MessageRequestSummary {
+    return {
+      id: request.id,
+      intro_note: request.intro_note,
+      status: request.status,
+      responded_at: request.responded_at,
+      created_at: request.created_at,
+      updated_at: request.updated_at,
+      recruiter: this.formatUser(request.recruiter),
+      talent: this.formatUser(request.talent),
+    };
+  }
+
+  private formatUser(user: UserEntity): MessageRequestUserSummary {
+    return {
+      id: user.id,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      avatar: user.avatar,
+      role: user.role,
+    };
+  }
+}

--- a/src/routes/index.route.ts
+++ b/src/routes/index.route.ts
@@ -1,5 +1,6 @@
 import authRoutes from "@src/auth/auth.route";
 import dashboardRoutes from "@src/dashboard/dashboard.route";
+import messagingRoutes from "@src/messaging/messaging.route";
 import onboardingRoutes from "@src/onboarding/onboarding.route";
 import skillsRoutes from "@src/skills/skills.route";
 import talentRoutes from "@src/talents/talent.route";
@@ -14,5 +15,6 @@ router.use("/skills", skillsRoutes);
 router.use("/users", userRoutes);
 router.use("/dashboard", dashboardRoutes);
 router.use("/talents", talentRoutes);
+router.use("/messages", messagingRoutes);
 
 export default router;


### PR DESCRIPTION
- Add endpoints to create, list incoming, and list outgoing message requests
- Enforce recruiter/talent role checks and approved talent eligibility
- Prevent duplicate pending requests, active conversations, and declined cooldown resends
- Add request validation, Swagger docs, and focused service tests