### PR TITLE
feat(messaging): add request accept and decline flow

### DIFF
--- a/src/__tests__/messaging/messageRequest.service.test.ts
+++ b/src/__tests__/messaging/messageRequest.service.test.ts
@@ -1,5 +1,6 @@
 import AppDataSource from "@src/datasource";
 import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import { MessageEntity } from "@src/entities/message.entity";
 import {
   MessageRequestEntity,
   MessageRequestStatus,
@@ -16,6 +17,9 @@ jest.mock("@src/datasource", () => ({
   __esModule: true,
   default: {
     getRepository: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   },
 }));
 
@@ -40,6 +44,17 @@ const mockRequestRepo = {
 
 const mockThreadRepo = {
   findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockMessageRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockTransactionManager = {
+  getRepository: jest.fn(),
 };
 
 const now = new Date("2026-07-28T12:00:00.000Z");
@@ -79,6 +94,34 @@ const buildRequest = (
     ...overrides,
   }) as MessageRequestEntity;
 
+const buildThread = (
+  overrides: Partial<ConversationThreadEntity> = {},
+): ConversationThreadEntity =>
+  ({
+    id: "44444444-4444-4444-8444-444444444444",
+    recruiter_last_seen_at: null,
+    talent_last_seen_at: null,
+    latest_message_at: null,
+    created_at: now,
+    updated_at: now,
+    accepted_request: null,
+    recruiter,
+    talent,
+    ...overrides,
+  }) as ConversationThreadEntity;
+
+const buildMessage = (overrides: Partial<MessageEntity> = {}): MessageEntity =>
+  ({
+    id: "55555555-5555-4555-8555-555555555555",
+    body: "We would like to chat.",
+    created_at: now,
+    updated_at: now,
+    sender: recruiter,
+    source_request: null,
+    thread: buildThread(),
+    ...overrides,
+  }) as MessageEntity;
+
 const mockUsersFound = () => {
   mockUserRepo.findOne.mockImplementation(({ where }) => {
     if (where.role === UserRole.RECRUITER) return Promise.resolve(recruiter);
@@ -105,6 +148,18 @@ describe("MessageRequestService", () => {
       if (entity === UserEntity) return mockUserRepo;
       if (entity === MessageRequestEntity) return mockRequestRepo;
       if (entity === ConversationThreadEntity) return mockThreadRepo;
+      if (entity === MessageEntity) return mockMessageRepo;
+      return {};
+    });
+
+    (AppDataSource.manager.transaction as jest.Mock).mockImplementation(
+      async (callback) => callback(mockTransactionManager),
+    );
+
+    mockTransactionManager.getRepository.mockImplementation((entity) => {
+      if (entity === MessageRequestEntity) return mockRequestRepo;
+      if (entity === ConversationThreadEntity) return mockThreadRepo;
+      if (entity === MessageEntity) return mockMessageRepo;
       return {};
     });
 
@@ -248,6 +303,152 @@ describe("MessageRequestService", () => {
       ).rejects.toThrow(ConflictError);
 
       expect(mockRequestRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("acceptMessageRequest", () => {
+    it("accepts a pending request, creates a thread, and converts the intro note into the first message", async () => {
+      const request = buildRequest({
+        intro_note: "We would like to schedule an interview.",
+      });
+      const savedThread = buildThread({
+        accepted_request: request,
+      });
+      const initialMessage = buildMessage({
+        body: request.intro_note,
+        source_request: request,
+        thread: savedThread,
+      });
+
+      mockRequestRepo.findOne.mockResolvedValue(request);
+      mockRequestRepo.save.mockImplementation(async (entity) => entity);
+      mockThreadRepo.findOne.mockResolvedValue(null);
+      mockThreadRepo.create.mockReturnValue(savedThread);
+      mockThreadRepo.save.mockImplementation(async (entity) => ({
+        ...entity,
+        id: entity.id || savedThread.id,
+        created_at: entity.created_at || now,
+        updated_at: now,
+      }));
+      mockMessageRepo.create.mockReturnValue(initialMessage);
+      mockMessageRepo.save.mockResolvedValue(initialMessage);
+
+      const result = await service.acceptMessageRequest(talent.id, request.id);
+
+      expect(AppDataSource.manager.transaction).toHaveBeenCalled();
+      expect(mockRequestRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: MessageRequestStatus.ACCEPTED,
+          responded_at: now,
+        }),
+      );
+      expect(mockThreadRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recruiter,
+          talent,
+          accepted_request: request,
+          latest_message_at: null,
+        }),
+      );
+      expect(mockMessageRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thread: expect.objectContaining({ id: savedThread.id }),
+          sender: recruiter,
+          source_request: request,
+          body: request.intro_note,
+          created_at: request.created_at,
+          updated_at: request.created_at,
+        }),
+      );
+      expect(mockThreadRepo.save).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          latest_message_at: initialMessage.created_at,
+        }),
+      );
+      expect(result.request.status).toBe(MessageRequestStatus.ACCEPTED);
+      expect(result.thread.accepted_request_id).toBe(request.id);
+      expect(result.initial_message).toEqual(
+        expect.objectContaining({
+          body: request.intro_note,
+          source_request_id: request.id,
+        }),
+      );
+    });
+
+    it("accepts a request without an intro note without creating an initial message", async () => {
+      const request = buildRequest({ intro_note: null });
+      const savedThread = buildThread({
+        accepted_request: request,
+      });
+
+      mockRequestRepo.findOne.mockResolvedValue(request);
+      mockRequestRepo.save.mockImplementation(async (entity) => entity);
+      mockThreadRepo.findOne.mockResolvedValue(null);
+      mockThreadRepo.create.mockReturnValue(savedThread);
+      mockThreadRepo.save.mockResolvedValue(savedThread);
+
+      const result = await service.acceptMessageRequest(talent.id, request.id);
+
+      expect(mockMessageRepo.create).not.toHaveBeenCalled();
+      expect(mockMessageRepo.save).not.toHaveBeenCalled();
+      expect(result.request.status).toBe(MessageRequestStatus.ACCEPTED);
+      expect(result.thread.accepted_request_id).toBe(request.id);
+      expect(result.initial_message).toBeNull();
+    });
+
+    it("rejects accept attempts for requests that do not belong to the talent", async () => {
+      const request = buildRequest();
+      mockRequestRepo.findOne.mockResolvedValue(request);
+
+      await expect(
+        service.acceptMessageRequest(
+          "99999999-9999-4999-8999-999999999999",
+          request.id,
+        ),
+      ).rejects.toThrow(NotFoundError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+      expect(mockThreadRepo.save).not.toHaveBeenCalled();
+      expect(mockMessageRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects accept attempts for requests that are no longer pending", async () => {
+      const request = buildRequest({
+        status: MessageRequestStatus.DECLINED,
+      });
+      mockRequestRepo.findOne.mockResolvedValue(request);
+
+      await expect(
+        service.acceptMessageRequest(talent.id, request.id),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockRequestRepo.save).not.toHaveBeenCalled();
+      expect(mockThreadRepo.save).not.toHaveBeenCalled();
+      expect(mockMessageRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("declineMessageRequest", () => {
+    it("declines a pending request without creating a thread or message", async () => {
+      const request = buildRequest();
+      mockRequestRepo.findOne.mockResolvedValue(request);
+      mockRequestRepo.save.mockImplementation(async (entity) => entity);
+
+      const result = await service.declineMessageRequest(talent.id, request.id);
+
+      expect(AppDataSource.manager.transaction).toHaveBeenCalled();
+      expect(mockRequestRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: MessageRequestStatus.DECLINED,
+          responded_at: now,
+        }),
+      );
+      expect(mockThreadRepo.create).not.toHaveBeenCalled();
+      expect(mockThreadRepo.save).not.toHaveBeenCalled();
+      expect(mockMessageRepo.create).not.toHaveBeenCalled();
+      expect(mockMessageRepo.save).not.toHaveBeenCalled();
+      expect(result.status).toBe(MessageRequestStatus.DECLINED);
+      expect(result.responded_at).toEqual(now);
     });
   });
 

--- a/src/docs/messaging.docs.ts
+++ b/src/docs/messaging.docs.ts
@@ -80,6 +80,61 @@
  *         hasPreviousPage:
  *           type: boolean
  *           example: false
+ *     ConversationThread:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *           example: "c3d4e5f6-3333-4444-8555-123456789abc"
+ *         recruiter_last_seen_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         talent_last_seen_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         latest_message_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         created_at:
+ *           type: string
+ *           format: date-time
+ *         updated_at:
+ *           type: string
+ *           format: date-time
+ *         accepted_request_id:
+ *           type: string
+ *           format: uuid
+ *           nullable: true
+ *         recruiter:
+ *           $ref: '#/components/schemas/MessageRequestUserSummary'
+ *         talent:
+ *           $ref: '#/components/schemas/MessageRequestUserSummary'
+ *     Message:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *           example: "d4e5f6a7-4444-4555-8666-123456789abc"
+ *         body:
+ *           type: string
+ *           example: "We would like to schedule an interview with you."
+ *         created_at:
+ *           type: string
+ *           format: date-time
+ *         updated_at:
+ *           type: string
+ *           format: date-time
+ *         source_request_id:
+ *           type: string
+ *           format: uuid
+ *           nullable: true
+ *         sender:
+ *           $ref: '#/components/schemas/MessageRequestUserSummary'
  */
 
 export const createMessageRequest = `
@@ -156,6 +211,164 @@ export const createMessageRequest = `
    *               $ref: '#/components/schemas/ErrorResponse'
    *       409:
    *         description: Conflict - pending request, active conversation, or declined-request cooldown already applies
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const acceptMessageRequest = `
+  /**
+   * @swagger
+   * /api/v1/messages/requests/{requestId}/accept:
+   *   patch:
+   *     summary: Accept an incoming message request
+   *     tags: [Messaging]
+   *     description: Allows a talent to accept a pending message request. Acceptance unlocks a persistent conversation thread for the recruiter and talent. If the recruiter sent an intro note, that note becomes the first visible message in the thread.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: requestId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: ID of the message request to accept
+   *     responses:
+   *       200:
+   *         description: Message request accepted successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Message request accepted successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     request:
+   *                       $ref: '#/components/schemas/MessageRequest'
+   *                     thread:
+   *                       $ref: '#/components/schemas/ConversationThread'
+   *                     initial_message:
+   *                       allOf:
+   *                         - $ref: '#/components/schemas/Message'
+   *                       nullable: true
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only talents can accept message requests
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       404:
+   *         description: Message request not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       409:
+   *         description: Conflict - request has already been accepted or declined
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const declineMessageRequest = `
+  /**
+   * @swagger
+   * /api/v1/messages/requests/{requestId}/decline:
+   *   patch:
+   *     summary: Decline an incoming message request
+   *     tags: [Messaging]
+   *     description: Allows a talent to decline a pending message request. Declining closes the request and does not create or unlock a conversation thread.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: requestId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: ID of the message request to decline
+   *     responses:
+   *       200:
+   *         description: Message request declined successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Message request declined successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     request:
+   *                       $ref: '#/components/schemas/MessageRequest'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only talents can decline message requests
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       404:
+   *         description: Message request not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       409:
+   *         description: Conflict - request has already been accepted or declined
    *         content:
    *           application/json:
    *             schema:

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,4 @@
+import { MessageRequestStatus } from "@src/entities/messageRequest.entity";
 import { NotificationType } from "@src/entities/notification.entity";
 import { UserRole } from "@src/entities/user.entity";
 import { RecruiterOnboardingDTO } from "@src/onboarding/schemas/recruiterOnboarding.schema";
@@ -54,6 +55,66 @@ export interface MetricsJobData {
 
 export interface IncompleteSignupReminderJobData {
   userId: string;
+}
+
+export interface MessageRequestUserSummary {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  avatar: string | null;
+  role: UserRole | null;
+}
+
+export interface MessageRequestSummary {
+  id: string;
+  intro_note: string | null;
+  status: MessageRequestStatus;
+  responded_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  recruiter: MessageRequestUserSummary;
+  talent: MessageRequestUserSummary;
+}
+
+export interface ConversationThreadSummary {
+  id: string;
+  recruiter_last_seen_at: Date | null;
+  talent_last_seen_at: Date | null;
+  latest_message_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  accepted_request_id: string | null;
+  recruiter: MessageRequestUserSummary;
+  talent: MessageRequestUserSummary;
+}
+
+export interface MessageSummary {
+  id: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  sender: MessageRequestUserSummary;
+  source_request_id: string | null;
+}
+
+export interface AcceptedMessageRequestSummary {
+  request: MessageRequestSummary;
+  thread: ConversationThreadSummary;
+  initial_message: MessageSummary | null;
+}
+
+export interface MessageRequestPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface PaginatedMessageRequestSummary {
+  requests: MessageRequestSummary[];
+  pagination: MessageRequestPagination;
 }
 
 export interface TalentSearchResult {

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -5,6 +5,21 @@ import { MessageRequestService } from "./services/messageRequest.service";
 
 const messageRequestService = new MessageRequestService();
 
+export const acceptMessageRequest = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await messageRequestService.acceptMessageRequest(
+      req.user.id,
+      req.params.requestId,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Message request accepted successfully",
+      data: result,
+    });
+  },
+);
+
 export const createMessageRequest = asyncHandler(
   async (req: Request, res: Response) => {
     const request = await messageRequestService.createMessageRequest(
@@ -15,6 +30,21 @@ export const createMessageRequest = asyncHandler(
     res.status(201).json({
       status: "success",
       message: "Message request sent successfully",
+      data: { request },
+    });
+  },
+);
+
+export const declineMessageRequest = asyncHandler(
+  async (req: Request, res: Response) => {
+    const request = await messageRequestService.declineMessageRequest(
+      req.user.id,
+      req.params.requestId,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Message request declined successfully",
       data: { request },
     });
   },

--- a/src/messaging/messaging.route.ts
+++ b/src/messaging/messaging.route.ts
@@ -4,13 +4,16 @@ import { deserializeUser } from "@src/middlewares/deserializeUser";
 import { validateData } from "@src/middlewares/validateData";
 import { Router } from "express";
 import {
+  acceptMessageRequest,
   createMessageRequest,
+  declineMessageRequest,
   getIncomingMessageRequests,
   getOutgoingMessageRequests,
 } from "./messaging.controller";
 import {
   createMessageRequestSchema,
   listMessageRequestsSchema,
+  messageRequestParamsSchema,
 } from "./schemas/messageRequest.schema";
 
 const router = Router();
@@ -36,6 +39,20 @@ router.get(
   checkRole(UserRole.RECRUITER),
   validateData(listMessageRequestsSchema, ["query"]),
   getOutgoingMessageRequests,
+);
+
+router.patch(
+  "/requests/:requestId/accept",
+  checkRole(UserRole.TALENT),
+  validateData(messageRequestParamsSchema, ["params"]),
+  acceptMessageRequest,
+);
+
+router.patch(
+  "/requests/:requestId/decline",
+  checkRole(UserRole.TALENT),
+  validateData(messageRequestParamsSchema, ["params"]),
+  declineMessageRequest,
 );
 
 export default router;

--- a/src/messaging/schemas/messageRequest.schema.ts
+++ b/src/messaging/schemas/messageRequest.schema.ts
@@ -12,6 +12,10 @@ export const listMessageRequestsSchema = z.object({
   limit: z.coerce.number().int().positive().max(100).default(20),
 });
 
+export const messageRequestParamsSchema = z.object({
+  requestId: z.string().uuid(),
+});
+
 export type CreateMessageRequestDto = z.infer<
   typeof createMessageRequestSchema
 >;

--- a/src/messaging/services/messageRequest.service.ts
+++ b/src/messaging/services/messageRequest.service.ts
@@ -1,5 +1,6 @@
 import AppDataSource from "@src/datasource";
 import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import { MessageEntity } from "@src/entities/message.entity";
 import {
   MessageRequestEntity,
   MessageRequestStatus,
@@ -13,6 +14,7 @@ import { ClientError } from "@src/exceptions/clientError";
 import { ConflictError } from "@src/exceptions/conflictError";
 import { NotFoundError } from "@src/exceptions/notFoundError";
 import config from "config";
+import { Repository } from "typeorm";
 import {
   CreateMessageRequestDto,
   ListMessageRequestsDto,
@@ -35,6 +37,33 @@ export interface MessageRequestSummary {
   updated_at: Date;
   recruiter: MessageRequestUserSummary;
   talent: MessageRequestUserSummary;
+}
+
+export interface ConversationThreadSummary {
+  id: string;
+  recruiter_last_seen_at: Date | null;
+  talent_last_seen_at: Date | null;
+  latest_message_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  accepted_request_id: string | null;
+  recruiter: MessageRequestUserSummary;
+  talent: MessageRequestUserSummary;
+}
+
+export interface MessageSummary {
+  id: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  sender: MessageRequestUserSummary;
+  source_request_id: string | null;
+}
+
+export interface AcceptedMessageRequestSummary {
+  request: MessageRequestSummary;
+  thread: ConversationThreadSummary;
+  initial_message: MessageSummary | null;
 }
 
 export interface MessageRequestPagination {
@@ -111,6 +140,94 @@ export class MessageRequestService {
       }
       throw error;
     }
+  }
+
+  async acceptMessageRequest(
+    talentId: string,
+    requestId: string,
+  ): Promise<AcceptedMessageRequestSummary> {
+    return AppDataSource.manager.transaction(async (manager) => {
+      const requestRepo = manager.getRepository(MessageRequestEntity);
+      const threadRepo = manager.getRepository(ConversationThreadEntity);
+      const messageRepo = manager.getRepository(MessageEntity);
+
+      const request = await requestRepo.findOne({
+        where: { id: requestId },
+        relations: ["recruiter", "talent"],
+      });
+
+      this.assertTalentCanRespondToRequest(request, talentId);
+
+      request.status = MessageRequestStatus.ACCEPTED;
+      request.responded_at = new Date();
+
+      const savedRequest = await requestRepo.save(request);
+
+      let thread = await threadRepo.findOne({
+        where: {
+          recruiter: { id: savedRequest.recruiter.id },
+          talent: { id: savedRequest.talent.id },
+        },
+        relations: ["recruiter", "talent", "accepted_request"],
+      });
+
+      if (!thread) {
+        thread = threadRepo.create({
+          recruiter: savedRequest.recruiter,
+          talent: savedRequest.talent,
+          accepted_request: savedRequest,
+          recruiter_last_seen_at: null,
+          talent_last_seen_at: null,
+          latest_message_at: null,
+        });
+      } else {
+        thread.accepted_request = savedRequest;
+      }
+
+      thread = await threadRepo.save(thread);
+
+      const initialMessage = await this.createInitialMessageFromRequest(
+        messageRepo,
+        savedRequest,
+        thread,
+      );
+
+      if (initialMessage) {
+        thread.latest_message_at =
+          initialMessage.created_at || savedRequest.created_at;
+        thread = await threadRepo.save(thread);
+      }
+
+      return {
+        request: this.formatMessageRequest(savedRequest),
+        thread: this.formatConversationThread(thread),
+        initial_message: initialMessage
+          ? this.formatMessage(initialMessage)
+          : null,
+      };
+    });
+  }
+
+  async declineMessageRequest(
+    talentId: string,
+    requestId: string,
+  ): Promise<MessageRequestSummary> {
+    return AppDataSource.manager.transaction(async (manager) => {
+      const requestRepo = manager.getRepository(MessageRequestEntity);
+
+      const request = await requestRepo.findOne({
+        where: { id: requestId },
+        relations: ["recruiter", "talent"],
+      });
+
+      this.assertTalentCanRespondToRequest(request, talentId);
+
+      request.status = MessageRequestStatus.DECLINED;
+      request.responded_at = new Date();
+
+      const savedRequest = await requestRepo.save(request);
+      return this.formatMessageRequest(savedRequest);
+    });
   }
 
   async getIncomingRequests(
@@ -233,6 +350,44 @@ export class MessageRequestService {
     }
   }
 
+  private assertTalentCanRespondToRequest(
+    request: MessageRequestEntity | null,
+    talentId: string,
+  ): asserts request is MessageRequestEntity {
+    if (!request || request.talent.id !== talentId) {
+      throw new NotFoundError("Message request not found");
+    }
+
+    if (request.status !== MessageRequestStatus.PENDING) {
+      throw new ConflictError(
+        `Message request has already been ${request.status}`,
+      );
+    }
+  }
+
+  private async createInitialMessageFromRequest(
+    messageRepo: Repository<MessageEntity>,
+    request: MessageRequestEntity,
+    thread: ConversationThreadEntity,
+  ): Promise<MessageEntity | null> {
+    const introNote = this.normalizeIntroNote(request.intro_note || undefined);
+
+    if (!introNote) {
+      return null;
+    }
+
+    const initialMessage = messageRepo.create({
+      thread,
+      sender: request.recruiter,
+      source_request: request,
+      body: introNote,
+      created_at: request.created_at,
+      updated_at: request.created_at,
+    });
+
+    return messageRepo.save(initialMessage);
+  }
+
   private isApprovedTalent(user: UserEntity | null): user is UserEntity & {
     talent_profile: TalentProfileEntity;
   } {
@@ -282,6 +437,33 @@ export class MessageRequestService {
       updated_at: request.updated_at,
       recruiter: this.formatUser(request.recruiter),
       talent: this.formatUser(request.talent),
+    };
+  }
+
+  private formatConversationThread(
+    thread: ConversationThreadEntity,
+  ): ConversationThreadSummary {
+    return {
+      id: thread.id,
+      recruiter_last_seen_at: thread.recruiter_last_seen_at,
+      talent_last_seen_at: thread.talent_last_seen_at,
+      latest_message_at: thread.latest_message_at,
+      created_at: thread.created_at,
+      updated_at: thread.updated_at,
+      accepted_request_id: thread.accepted_request?.id || null,
+      recruiter: this.formatUser(thread.recruiter),
+      talent: this.formatUser(thread.talent),
+    };
+  }
+
+  private formatMessage(message: MessageEntity): MessageSummary {
+    return {
+      id: message.id,
+      body: message.body,
+      created_at: message.created_at,
+      updated_at: message.updated_at,
+      sender: this.formatUser(message.sender),
+      source_request_id: message.source_request?.id || null,
     };
   }
 

--- a/src/messaging/services/messageRequest.service.ts
+++ b/src/messaging/services/messageRequest.service.ts
@@ -13,72 +13,20 @@ import { UserEntity, UserRole } from "@src/entities/user.entity";
 import { ClientError } from "@src/exceptions/clientError";
 import { ConflictError } from "@src/exceptions/conflictError";
 import { NotFoundError } from "@src/exceptions/notFoundError";
+import {
+  AcceptedMessageRequestSummary,
+  ConversationThreadSummary,
+  MessageRequestSummary,
+  MessageRequestUserSummary,
+  MessageSummary,
+  PaginatedMessageRequestSummary,
+} from "@src/interfaces";
 import config from "config";
 import { Repository } from "typeorm";
 import {
   CreateMessageRequestDto,
   ListMessageRequestsDto,
 } from "../schemas/messageRequest.schema";
-
-interface MessageRequestUserSummary {
-  id: string;
-  first_name: string | null;
-  last_name: string | null;
-  avatar: string | null;
-  role: UserRole | null;
-}
-
-export interface MessageRequestSummary {
-  id: string;
-  intro_note: string | null;
-  status: MessageRequestStatus;
-  responded_at: Date | null;
-  created_at: Date;
-  updated_at: Date;
-  recruiter: MessageRequestUserSummary;
-  talent: MessageRequestUserSummary;
-}
-
-export interface ConversationThreadSummary {
-  id: string;
-  recruiter_last_seen_at: Date | null;
-  talent_last_seen_at: Date | null;
-  latest_message_at: Date | null;
-  created_at: Date;
-  updated_at: Date;
-  accepted_request_id: string | null;
-  recruiter: MessageRequestUserSummary;
-  talent: MessageRequestUserSummary;
-}
-
-export interface MessageSummary {
-  id: string;
-  body: string;
-  created_at: Date;
-  updated_at: Date;
-  sender: MessageRequestUserSummary;
-  source_request_id: string | null;
-}
-
-export interface AcceptedMessageRequestSummary {
-  request: MessageRequestSummary;
-  thread: ConversationThreadSummary;
-  initial_message: MessageSummary | null;
-}
-
-export interface MessageRequestPagination {
-  page: number;
-  limit: number;
-  total: number;
-  totalPages: number;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-}
-
-export interface PaginatedMessageRequestSummary {
-  requests: MessageRequestSummary[];
-  pagination: MessageRequestPagination;
-}
 
 export class MessageRequestService {
   private readonly userRepo = AppDataSource.getRepository(UserEntity);


### PR DESCRIPTION
- Add accept and decline endpoints for message requests
- Unlock conversation thread on acceptance
- Convert intro note into the first visible thread message
- Keep declined requests closed without creating a thread
- Add Swagger docs and focused service tests