### PR TITLE
feat: add direct messaging inbox and conversation flow

### DIFF
--- a/src/__tests__/messaging/conversation.service.test.ts
+++ b/src/__tests__/messaging/conversation.service.test.ts
@@ -1,0 +1,275 @@
+import AppDataSource from "@src/datasource";
+import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import { MessageEntity } from "@src/entities/message.entity";
+import {
+  MessageRequestEntity,
+  MessageRequestStatus,
+} from "@src/entities/messageRequest.entity";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import { ConflictError } from "@src/exceptions/conflictError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
+import { ConversationService } from "@src/messaging/services/conversation.service";
+
+jest.mock("@src/datasource", () => ({
+  __esModule: true,
+  default: {
+    getRepository: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
+  },
+}));
+
+const mockThreadRepo = {
+  findAndCount: jest.fn(),
+  findOne: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockMessageRepo = {
+  create: jest.fn(),
+  findAndCount: jest.fn(),
+  findOne: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockTransactionManager = {
+  getRepository: jest.fn(),
+};
+
+const now = new Date("2026-08-01T10:00:00.000Z");
+const later = new Date("2026-08-01T10:05:00.000Z");
+
+const recruiter = {
+  id: "11111111-1111-4111-8111-111111111111",
+  first_name: "Ada",
+  last_name: "Recruiter",
+  avatar: null,
+  role: UserRole.RECRUITER,
+} as UserEntity;
+
+const talent = {
+  id: "22222222-2222-4222-8222-222222222222",
+  first_name: "Tola",
+  last_name: "Talent",
+  avatar: "uploads/avatars/tola.png",
+  role: UserRole.TALENT,
+} as UserEntity;
+
+const acceptedRequest = {
+  id: "33333333-3333-4333-8333-333333333333",
+  status: MessageRequestStatus.ACCEPTED,
+  recruiter,
+  talent,
+} as MessageRequestEntity;
+
+const buildThread = (
+  overrides: Partial<ConversationThreadEntity> = {},
+): ConversationThreadEntity =>
+  ({
+    id: "44444444-4444-4444-8444-444444444444",
+    recruiter,
+    talent,
+    accepted_request: acceptedRequest,
+    recruiter_last_seen_at: null,
+    talent_last_seen_at: null,
+    latest_message_at: later,
+    created_at: now,
+    updated_at: later,
+    ...overrides,
+  }) as ConversationThreadEntity;
+
+const buildMessage = (overrides: Partial<MessageEntity> = {}): MessageEntity =>
+  ({
+    id: "55555555-5555-4555-8555-555555555555",
+    body: "Hello there",
+    sender: recruiter,
+    source_request: null,
+    thread: buildThread(),
+    created_at: later,
+    updated_at: later,
+    ...overrides,
+  }) as MessageEntity;
+
+describe("ConversationService", () => {
+  let service: ConversationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(later);
+
+    (AppDataSource.getRepository as jest.Mock).mockImplementation((entity) => {
+      if (entity === ConversationThreadEntity) return mockThreadRepo;
+      if (entity === MessageEntity) return mockMessageRepo;
+      return {};
+    });
+
+    (AppDataSource.manager.transaction as jest.Mock).mockImplementation(
+      async (callback) => callback(mockTransactionManager),
+    );
+
+    mockTransactionManager.getRepository.mockImplementation((entity) => {
+      if (entity === ConversationThreadEntity) return mockThreadRepo;
+      if (entity === MessageEntity) return mockMessageRepo;
+      return {};
+    });
+
+    service = new ConversationService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("getInbox", () => {
+    it("lists active recruiter threads with latest message summaries", async () => {
+      const thread = buildThread();
+      const latestMessage = buildMessage({ body: "Latest update" });
+      mockThreadRepo.findAndCount.mockResolvedValue([[thread], 1]);
+      mockMessageRepo.findOne.mockResolvedValue(latestMessage);
+
+      const result = await service.getInbox(recruiter.id, UserRole.RECRUITER, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(mockThreadRepo.findAndCount).toHaveBeenCalledWith({
+        where: {
+          recruiter: { id: recruiter.id },
+          accepted_request: { status: MessageRequestStatus.ACCEPTED },
+        },
+        relations: ["recruiter", "talent", "accepted_request"],
+        order: { latest_message_at: "DESC", updated_at: "DESC" },
+        skip: 0,
+        take: 20,
+      });
+      expect(mockMessageRepo.findOne).toHaveBeenCalledWith({
+        where: { thread: { id: thread.id } },
+        relations: ["sender", "source_request"],
+        order: { created_at: "DESC" },
+      });
+      expect(result.threads[0].conversation_partner.id).toBe(talent.id);
+      expect(result.threads[0].latest_message?.body).toBe("Latest update");
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
+  });
+
+  describe("getMessages", () => {
+    it("loads the most recent message page and returns that page in chronological order", async () => {
+      const thread = buildThread();
+      const messages = [
+        buildMessage({ id: "message-2", body: "Second", created_at: later }),
+        buildMessage({ id: "message-1", body: "First", created_at: now }),
+      ];
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+      mockMessageRepo.findAndCount.mockResolvedValue([messages, 2]);
+
+      const result = await service.getMessages(recruiter.id, thread.id, {
+        page: 1,
+        limit: 50,
+      });
+
+      expect(mockThreadRepo.findOne).toHaveBeenCalledWith({
+        where: { id: thread.id },
+        relations: ["recruiter", "talent", "accepted_request"],
+      });
+      expect(mockMessageRepo.findAndCount).toHaveBeenCalledWith({
+        where: { thread: { id: thread.id } },
+        relations: ["sender", "source_request"],
+        order: { created_at: "DESC" },
+        skip: 0,
+        take: 50,
+      });
+      expect(result.messages.map((message) => message.body)).toEqual([
+        "First",
+        "Second",
+      ]);
+    });
+
+    it("hides threads from non-participants", async () => {
+      const thread = buildThread();
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+
+      await expect(
+        service.getMessages("99999999-9999-4999-8999-999999999999", thread.id, {
+          page: 1,
+          limit: 50,
+        }),
+      ).rejects.toThrow(NotFoundError);
+
+      expect(mockMessageRepo.findAndCount).not.toHaveBeenCalled();
+    });
+
+    it("blocks messages for inactive threads", async () => {
+      const thread = buildThread({ accepted_request: null });
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+
+      await expect(
+        service.getMessages(recruiter.id, thread.id, {
+          page: 1,
+          limit: 50,
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockMessageRepo.findAndCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("sends a message in an active thread and updates latest activity", async () => {
+      const thread = buildThread();
+      const body = "Thanks for accepting.\nCan we schedule a call?";
+      const savedMessage = buildMessage({
+        body,
+        sender: talent,
+        thread,
+        created_at: later,
+      });
+
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+      mockMessageRepo.create.mockReturnValue(savedMessage);
+      mockMessageRepo.save.mockResolvedValue(savedMessage);
+      mockThreadRepo.save.mockImplementation(async (entity) => entity);
+
+      const result = await service.sendMessage(talent.id, thread.id, { body });
+
+      expect(AppDataSource.manager.transaction).toHaveBeenCalled();
+      expect(mockMessageRepo.create).toHaveBeenCalledWith({
+        thread,
+        sender: talent,
+        body,
+        source_request: null,
+      });
+      expect(mockMessageRepo.save).toHaveBeenCalledWith(savedMessage);
+      expect(mockThreadRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ latest_message_at: later }),
+      );
+      expect(result.message.body).toBe(body);
+      expect(result.thread.latest_message_at).toEqual(later);
+    });
+
+    it("blocks sending to inactive threads", async () => {
+      const thread = buildThread({
+        accepted_request: {
+          ...acceptedRequest,
+          status: MessageRequestStatus.DECLINED,
+        } as MessageRequestEntity,
+      });
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+
+      await expect(
+        service.sendMessage(recruiter.id, thread.id, { body: "Hello" }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(mockMessageRepo.save).not.toHaveBeenCalled();
+      expect(mockThreadRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/docs/messaging.docs.ts
+++ b/src/docs/messaging.docs.ts
@@ -59,7 +59,7 @@
  *           $ref: '#/components/schemas/MessageRequestUserSummary'
  *         talent:
  *           $ref: '#/components/schemas/MessageRequestUserSummary'
- *     MessageRequestPagination:
+ *     PaginationMeta:
  *       type: object
  *       properties:
  *         page:
@@ -135,7 +135,281 @@
  *           nullable: true
  *         sender:
  *           $ref: '#/components/schemas/MessageRequestUserSummary'
+ *     ConversationInboxItem:
+ *       allOf:
+ *         - $ref: '#/components/schemas/ConversationThread'
+ *         - type: object
+ *           properties:
+ *             conversation_partner:
+ *               $ref: '#/components/schemas/MessageRequestUserSummary'
+ *             latest_message:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Message'
+ *               nullable: true
  */
+
+export const getConversationInbox = `
+  /**
+   * @swagger
+   * /api/v1/messages/threads:
+   *   get:
+   *     summary: List active conversation threads
+   *     tags: [Messaging]
+   *     description: Returns accepted conversation threads for the authenticated recruiter or talent, sorted by most recent activity.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           type: integer
+   *           default: 1
+   *           minimum: 1
+   *         description: Page number to return
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 20
+   *           minimum: 1
+   *           maximum: 100
+   *         description: Maximum number of threads to return
+   *     responses:
+   *       200:
+   *         description: Conversation inbox fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Conversation inbox fetched successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     threads:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/ConversationInboxItem'
+   *                     pagination:
+   *                       $ref: '#/components/schemas/PaginationMeta'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only recruiters and talents can view conversations
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const getConversationMessages = `
+  /**
+   * @swagger
+   * /api/v1/messages/threads/{threadId}/messages:
+   *   get:
+   *     summary: List messages in an active conversation thread
+   *     tags: [Messaging]
+   *     description: Returns messages for an accepted conversation thread. Page 1 loads the most recent messages, and higher pages fetch older history. Messages within each page are returned oldest-to-newest for display. Only the recruiter or talent who belongs to the thread can access it.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: threadId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: ID of the conversation thread
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           type: integer
+   *           default: 1
+   *           minimum: 1
+   *         description: Page number to return
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 50
+   *           minimum: 1
+   *           maximum: 100
+   *         description: Maximum number of messages to return
+   *     responses:
+   *       200:
+   *         description: Conversation messages fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Conversation messages fetched successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     messages:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/Message'
+   *                     pagination:
+   *                       $ref: '#/components/schemas/PaginationMeta'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only thread participants can view messages
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       404:
+   *         description: Conversation thread not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       409:
+   *         description: Conflict - conversation is not active
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const sendConversationMessage = `
+  /**
+   * @swagger
+   * /api/v1/messages/threads/{threadId}/messages:
+   *   post:
+   *     summary: Send a message in an active conversation thread
+   *     tags: [Messaging]
+   *     description: Sends a free-text message in an accepted conversation thread. Line breaks are preserved in the message body.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: threadId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: ID of the conversation thread
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - body
+   *             properties:
+   *               body:
+   *                 type: string
+   *                 minLength: 1
+   *                 maxLength: 5000
+   *                 example: "Thanks for accepting.\\nCan we schedule a call this week?"
+   *     responses:
+   *       201:
+   *         description: Message sent successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Message sent successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     thread:
+   *                       $ref: '#/components/schemas/ConversationThread'
+   *                     message:
+   *                       $ref: '#/components/schemas/Message'
+   *       401:
+   *         description: Unauthorized - token missing or invalid
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - only thread participants can send messages
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       404:
+   *         description: Conversation thread not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       409:
+   *         description: Conflict - conversation is not active
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       422:
+   *         description: Validation error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
 
 export const createMessageRequest = `
   /**
@@ -442,7 +716,7 @@ export const getIncomingMessageRequests = `
    *                       items:
    *                         $ref: '#/components/schemas/MessageRequest'
   *                     pagination:
-  *                       $ref: '#/components/schemas/MessageRequestPagination'
+  *                       $ref: '#/components/schemas/PaginationMeta'
    *       401:
    *         description: Unauthorized - token missing or invalid
    *         content:
@@ -524,7 +798,7 @@ export const getOutgoingMessageRequests = `
    *                       items:
    *                         $ref: '#/components/schemas/MessageRequest'
   *                     pagination:
-  *                       $ref: '#/components/schemas/MessageRequestPagination'
+  *                       $ref: '#/components/schemas/PaginationMeta'
    *       401:
    *         description: Unauthorized - token missing or invalid
    *         content:

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -103,7 +103,7 @@ export interface AcceptedMessageRequestSummary {
   initial_message: MessageSummary | null;
 }
 
-export interface MessageRequestPagination {
+export interface PaginationMeta {
   page: number;
   limit: number;
   total: number;
@@ -112,9 +112,32 @@ export interface MessageRequestPagination {
   hasPreviousPage: boolean;
 }
 
+export interface MessageRequestPagination extends PaginationMeta {}
+
 export interface PaginatedMessageRequestSummary {
   requests: MessageRequestSummary[];
   pagination: MessageRequestPagination;
+}
+
+export interface ConversationInboxItemSummary
+  extends ConversationThreadSummary {
+  conversation_partner: MessageRequestUserSummary;
+  latest_message: MessageSummary | null;
+}
+
+export interface PaginatedConversationInboxSummary {
+  threads: ConversationInboxItemSummary[];
+  pagination: PaginationMeta;
+}
+
+export interface PaginatedMessageSummary {
+  messages: MessageSummary[];
+  pagination: PaginationMeta;
+}
+
+export interface SentConversationMessageSummary {
+  thread: ConversationThreadSummary;
+  message: MessageSummary;
 }
 
 export interface TalentSearchResult {

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -1,9 +1,15 @@
 import asyncHandler from "@src/middlewares/asyncHandler";
 import { Request, Response } from "express";
+import {
+  ListConversationMessagesDto,
+  ListConversationThreadsDto,
+} from "./schemas/conversation.schema";
 import { ListMessageRequestsDto } from "./schemas/messageRequest.schema";
+import { ConversationService } from "./services/conversation.service";
 import { MessageRequestService } from "./services/messageRequest.service";
 
 const messageRequestService = new MessageRequestService();
+const conversationService = new ConversationService();
 
 export const acceptMessageRequest = asyncHandler(
   async (req: Request, res: Response) => {
@@ -65,6 +71,38 @@ export const getIncomingMessageRequests = asyncHandler(
   },
 );
 
+export const getConversationInbox = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await conversationService.getInbox(
+      req.user.id,
+      req.user.role,
+      req.query as ListConversationThreadsDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Conversation inbox fetched successfully",
+      data: result,
+    });
+  },
+);
+
+export const getConversationMessages = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await conversationService.getMessages(
+      req.user.id,
+      req.params.threadId,
+      req.query as ListConversationMessagesDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Conversation messages fetched successfully",
+      data: result,
+    });
+  },
+);
+
 export const getOutgoingMessageRequests = asyncHandler(
   async (req: Request, res: Response) => {
     const result = await messageRequestService.getOutgoingRequests(
@@ -75,6 +113,22 @@ export const getOutgoingMessageRequests = asyncHandler(
     res.status(200).json({
       status: "success",
       message: "Outgoing message requests fetched successfully",
+      data: result,
+    });
+  },
+);
+
+export const sendConversationMessage = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await conversationService.sendMessage(
+      req.user.id,
+      req.params.threadId,
+      req.body,
+    );
+
+    res.status(201).json({
+      status: "success",
+      message: "Message sent successfully",
       data: result,
     });
   },

--- a/src/messaging/messaging.route.ts
+++ b/src/messaging/messaging.route.ts
@@ -7,9 +7,18 @@ import {
   acceptMessageRequest,
   createMessageRequest,
   declineMessageRequest,
+  getConversationInbox,
+  getConversationMessages,
   getIncomingMessageRequests,
   getOutgoingMessageRequests,
+  sendConversationMessage,
 } from "./messaging.controller";
+import {
+  conversationThreadParamsSchema,
+  listConversationMessagesSchema,
+  listConversationThreadsSchema,
+  sendConversationMessageSchema,
+} from "./schemas/conversation.schema";
 import {
   createMessageRequestSchema,
   listMessageRequestsSchema,
@@ -19,6 +28,29 @@ import {
 const router = Router();
 
 router.use(deserializeUser);
+
+router.get(
+  "/threads",
+  checkRole([UserRole.RECRUITER, UserRole.TALENT]),
+  validateData(listConversationThreadsSchema, ["query"]),
+  getConversationInbox,
+);
+
+router.get(
+  "/threads/:threadId/messages",
+  checkRole([UserRole.RECRUITER, UserRole.TALENT]),
+  validateData(conversationThreadParamsSchema, ["params"]),
+  validateData(listConversationMessagesSchema, ["query"]),
+  getConversationMessages,
+);
+
+router.post(
+  "/threads/:threadId/messages",
+  checkRole([UserRole.RECRUITER, UserRole.TALENT]),
+  validateData(conversationThreadParamsSchema, ["params"]),
+  validateData(sendConversationMessageSchema),
+  sendConversationMessage,
+);
 
 router.post(
   "/requests",

--- a/src/messaging/schemas/conversation.schema.ts
+++ b/src/messaging/schemas/conversation.schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const conversationThreadParamsSchema = z.object({
+  threadId: z.string().uuid(),
+});
+
+export const listConversationThreadsSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export const listConversationMessagesSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(50),
+});
+
+export const sendConversationMessageSchema = z.object({
+  body: z.string().trim().min(1).max(5000),
+});
+
+export type ListConversationThreadsDto = z.infer<
+  typeof listConversationThreadsSchema
+>;
+
+export type ListConversationMessagesDto = z.infer<
+  typeof listConversationMessagesSchema
+>;
+
+export type SendConversationMessageDto = z.infer<
+  typeof sendConversationMessageSchema
+>;

--- a/src/messaging/services/conversation.service.ts
+++ b/src/messaging/services/conversation.service.ts
@@ -1,0 +1,235 @@
+import AppDataSource from "@src/datasource";
+import { ConversationThreadEntity } from "@src/entities/conversationThread.entity";
+import { MessageEntity } from "@src/entities/message.entity";
+import { MessageRequestStatus } from "@src/entities/messageRequest.entity";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import { ConflictError } from "@src/exceptions/conflictError";
+import { NotFoundError } from "@src/exceptions/notFoundError";
+import {
+  ConversationInboxItemSummary,
+  ConversationThreadSummary,
+  MessageRequestUserSummary,
+  MessageSummary,
+  PaginatedConversationInboxSummary,
+  PaginatedMessageSummary,
+  SentConversationMessageSummary,
+} from "@src/interfaces";
+import {
+  ListConversationMessagesDto,
+  ListConversationThreadsDto,
+  SendConversationMessageDto,
+} from "../schemas/conversation.schema";
+
+export class ConversationService {
+  private readonly threadRepo = AppDataSource.getRepository(
+    ConversationThreadEntity,
+  );
+  private readonly messageRepo = AppDataSource.getRepository(MessageEntity);
+
+  async getInbox(
+    userId: string,
+    role: UserRole,
+    query: ListConversationThreadsDto,
+  ): Promise<PaginatedConversationInboxSummary> {
+    const page = query.page ?? 1;
+    const limit = query.limit;
+    const skip = (page - 1) * limit;
+
+    const [threads, total] = await this.threadRepo.findAndCount({
+      where: {
+        ...(role === UserRole.RECRUITER
+          ? { recruiter: { id: userId } }
+          : { talent: { id: userId } }),
+        accepted_request: { status: MessageRequestStatus.ACCEPTED },
+      },
+      relations: ["recruiter", "talent", "accepted_request"],
+      order: { latest_message_at: "DESC", updated_at: "DESC" },
+      skip,
+      take: limit,
+    });
+
+    const latestMessages = await Promise.all(
+      threads.map((thread) => this.findLatestMessage(thread.id)),
+    );
+
+    return {
+      threads: threads.map((thread, index) =>
+        this.formatInboxItem(thread, userId, latestMessages[index]),
+      ),
+      pagination: this.buildPagination(page, limit, total),
+    };
+  }
+
+  async getMessages(
+    userId: string,
+    threadId: string,
+    query: ListConversationMessagesDto,
+  ): Promise<PaginatedMessageSummary> {
+    const thread = await this.findAccessibleActiveThread(threadId, userId);
+    const page = query.page ?? 1;
+    const limit = query.limit;
+    const skip = (page - 1) * limit;
+
+    const [messages, total] = await this.messageRepo.findAndCount({
+      where: { thread: { id: thread.id } },
+      relations: ["sender", "source_request"],
+      order: { created_at: "DESC" },
+      skip,
+      take: limit,
+    });
+
+    return {
+      messages: messages
+        .reverse()
+        .map((message) => this.formatMessage(message)),
+      pagination: this.buildPagination(page, limit, total),
+    };
+  }
+
+  async sendMessage(
+    userId: string,
+    threadId: string,
+    payload: SendConversationMessageDto,
+  ): Promise<SentConversationMessageSummary> {
+    return AppDataSource.manager.transaction(async (manager) => {
+      const threadRepo = manager.getRepository(ConversationThreadEntity);
+      const messageRepo = manager.getRepository(MessageEntity);
+
+      const thread = await threadRepo.findOne({
+        where: { id: threadId },
+        relations: ["recruiter", "talent", "accepted_request"],
+      });
+
+      this.assertThreadIsAccessibleAndActive(thread, userId);
+
+      const sender = this.resolveParticipant(thread, userId);
+      const message = messageRepo.create({
+        thread,
+        sender,
+        body: payload.body,
+        source_request: null,
+      });
+      const savedMessage = await messageRepo.save(message);
+
+      thread.latest_message_at = savedMessage.created_at || new Date();
+      const savedThread = await threadRepo.save(thread);
+
+      return {
+        thread: this.formatConversationThread(savedThread),
+        message: this.formatMessage(savedMessage),
+      };
+    });
+  }
+
+  private async findAccessibleActiveThread(
+    threadId: string,
+    userId: string,
+  ): Promise<ConversationThreadEntity> {
+    const thread = await this.threadRepo.findOne({
+      where: { id: threadId },
+      relations: ["recruiter", "talent", "accepted_request"],
+    });
+
+    this.assertThreadIsAccessibleAndActive(thread, userId);
+    return thread;
+  }
+
+  private assertThreadIsAccessibleAndActive(
+    thread: ConversationThreadEntity | null,
+    userId: string,
+  ): asserts thread is ConversationThreadEntity {
+    if (!thread || !this.isParticipant(thread, userId)) {
+      throw new NotFoundError("Conversation thread not found");
+    }
+
+    if (thread.accepted_request?.status !== MessageRequestStatus.ACCEPTED) {
+      throw new ConflictError("Conversation is not active");
+    }
+  }
+
+  private async findLatestMessage(
+    threadId: string,
+  ): Promise<MessageEntity | null> {
+    return this.messageRepo.findOne({
+      where: { thread: { id: threadId } },
+      relations: ["sender", "source_request"],
+      order: { created_at: "DESC" },
+    });
+  }
+
+  private formatInboxItem(
+    thread: ConversationThreadEntity,
+    userId: string,
+    latestMessage: MessageEntity | null,
+  ): ConversationInboxItemSummary {
+    return {
+      ...this.formatConversationThread(thread),
+      conversation_partner: this.formatUser(
+        thread.recruiter.id === userId ? thread.talent : thread.recruiter,
+      ),
+      latest_message: latestMessage ? this.formatMessage(latestMessage) : null,
+    };
+  }
+
+  private formatConversationThread(
+    thread: ConversationThreadEntity,
+  ): ConversationThreadSummary {
+    return {
+      id: thread.id,
+      recruiter_last_seen_at: thread.recruiter_last_seen_at,
+      talent_last_seen_at: thread.talent_last_seen_at,
+      latest_message_at: thread.latest_message_at,
+      created_at: thread.created_at,
+      updated_at: thread.updated_at,
+      accepted_request_id: thread.accepted_request?.id || null,
+      recruiter: this.formatUser(thread.recruiter),
+      talent: this.formatUser(thread.talent),
+    };
+  }
+
+  private formatMessage(message: MessageEntity): MessageSummary {
+    return {
+      id: message.id,
+      body: message.body,
+      created_at: message.created_at,
+      updated_at: message.updated_at,
+      sender: this.formatUser(message.sender),
+      source_request_id: message.source_request?.id || null,
+    };
+  }
+
+  private formatUser(user: UserEntity): MessageRequestUserSummary {
+    return {
+      id: user.id,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      avatar: user.avatar,
+      role: user.role,
+    };
+  }
+
+  private resolveParticipant(
+    thread: ConversationThreadEntity,
+    userId: string,
+  ): UserEntity {
+    return thread.recruiter.id === userId ? thread.recruiter : thread.talent;
+  }
+
+  private isParticipant(
+    thread: ConversationThreadEntity,
+    userId: string,
+  ): boolean {
+    return thread.recruiter.id === userId || thread.talent.id === userId;
+  }
+
+  private buildPagination(page: number, limit: number, total: number) {
+    return {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+      hasNextPage: page * limit < total,
+      hasPreviousPage: page > 1,
+    };
+  }
+}


### PR DESCRIPTION
**Summary**
This PR introduces the initial backend support for direct messaging between recruiters and talents, including message requests and conversation threads.

**What’s included**
Added endpoints to create, accept, decline, and list message requests
Implemented conversation inbox and message retrieval flows
Enabled sending messages within an active conversation thread
Added response payloads for requests, threads, and messages

**Why**
This lays the foundation for the messaging experience in the product and supports the first version of recruiter-to-talent communication.

**Notes**
Focused on the core backend messaging workflow
Prepared to support frontend integration for inbox and conversation views