### PR TITLE
 feat(messaging): add seen status and personalized role-based message templates

### DIFF
--- a/src/__tests__/messaging/conversation.service.test.ts
+++ b/src/__tests__/messaging/conversation.service.test.ts
@@ -150,6 +150,8 @@ describe("ConversationService", () => {
       });
       expect(result.threads[0].conversation_partner.id).toBe(talent.id);
       expect(result.threads[0].latest_message?.body).toBe("Latest update");
+      expect(result.threads[0].latest_message_seen_at).toBeNull();
+      expect(result.threads[0].latest_message_seen_status).toBe("unseen");
       expect(result.pagination).toEqual({
         page: 1,
         limit: 20,
@@ -249,10 +251,15 @@ describe("ConversationService", () => {
       });
       expect(mockMessageRepo.save).toHaveBeenCalledWith(savedMessage);
       expect(mockThreadRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ latest_message_at: later }),
+        expect.objectContaining({
+          latest_message_at: later,
+          talent_last_seen_at: later,
+        }),
       );
       expect(result.message.body).toBe(body);
       expect(result.thread.latest_message_at).toEqual(later);
+      expect(result.thread.latest_message_seen_at).toEqual(later);
+      expect(result.thread.latest_message_seen_status).toBe("seen");
     });
 
     it("blocks sending to inactive threads", async () => {
@@ -270,6 +277,46 @@ describe("ConversationService", () => {
 
       expect(mockMessageRepo.save).not.toHaveBeenCalled();
       expect(mockThreadRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("markThreadAsSeen", () => {
+    it("updates participant seen timestamp and returns seen status", async () => {
+      const thread = buildThread({ recruiter_last_seen_at: null });
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+      mockThreadRepo.save.mockImplementation(async (entity) => entity);
+
+      const result = await service.markThreadAsSeen(
+        recruiter.id,
+        thread.id,
+        {},
+      );
+
+      expect(AppDataSource.manager.transaction).toHaveBeenCalled();
+      expect(mockThreadRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ recruiter_last_seen_at: later }),
+      );
+      expect(result.latest_message_seen_at).toEqual(later);
+      expect(result.latest_message_seen_status).toBe("seen");
+    });
+
+    it("keeps the later seen timestamp when an older timestamp is provided", async () => {
+      const existingSeenAt = new Date("2026-08-01T10:06:00.000Z");
+      const olderSeenAt = new Date("2026-08-01T10:04:00.000Z");
+      const thread = buildThread({ recruiter_last_seen_at: existingSeenAt });
+
+      mockThreadRepo.findOne.mockResolvedValue(thread);
+      mockThreadRepo.save.mockImplementation(async (entity) => entity);
+
+      const result = await service.markThreadAsSeen(recruiter.id, thread.id, {
+        seen_at: olderSeenAt,
+      });
+
+      expect(mockThreadRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ recruiter_last_seen_at: existingSeenAt }),
+      );
+      expect(result.latest_message_seen_at).toEqual(existingSeenAt);
+      expect(result.latest_message_seen_status).toBe("seen");
     });
   });
 });

--- a/src/__tests__/messaging/messageTemplate.service.test.ts
+++ b/src/__tests__/messaging/messageTemplate.service.test.ts
@@ -1,0 +1,196 @@
+import AppDataSource from "@src/datasource";
+import { UserProvider, UserRole } from "@src/entities/user.entity";
+import {
+  MessageTemplateService,
+  RECRUITER_TEMPLATE_IDS,
+  TALENT_TEMPLATE_IDS,
+} from "@src/messaging/services/messageTemplate.service";
+
+jest.mock("@src/datasource", () => ({
+  __esModule: true,
+  default: {
+    getRepository: jest.fn(),
+  },
+}));
+
+const mockUserRepo = {
+  findOne: jest.fn(),
+};
+
+const recruiter = {
+  id: "11111111-1111-4111-8111-111111111111",
+  first_name: "Cameron",
+  talent_profile: null,
+};
+
+const talent = {
+  id: "22222222-2222-4222-8222-222222222222",
+  first_name: "Sharon",
+  talent_profile: {
+    job_title: "frontend development",
+    portfolio_url: "https://portfolio.example/sharon",
+  },
+};
+
+const localRecruiterWithoutNames = {
+  id: "33333333-3333-4333-8333-333333333333",
+  first_name: null,
+  last_name: null,
+  provider: UserProvider.LOCAL,
+  role: UserRole.RECRUITER,
+  talent_profile: null,
+};
+
+const oauthTalentWithNames = {
+  id: "44444444-4444-4444-8444-444444444444",
+  first_name: "Alex",
+  last_name: "Morgan",
+  provider: UserProvider.GOOGLE,
+  role: UserRole.TALENT,
+  talent_profile: null,
+};
+
+describe("MessageTemplateService", () => {
+  let service: MessageTemplateService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (AppDataSource.getRepository as jest.Mock).mockReturnValue(mockUserRepo);
+    mockUserRepo.findOne.mockImplementation(({ where }) => {
+      if (where.id === recruiter.id) return Promise.resolve(recruiter);
+      if (where.id === talent.id) return Promise.resolve(talent);
+      if (where.id === localRecruiterWithoutNames.id) {
+        return Promise.resolve(localRecruiterWithoutNames);
+      }
+      if (where.id === oauthTalentWithNames.id) {
+        return Promise.resolve(oauthTalentWithNames);
+      }
+      return Promise.resolve(null);
+    });
+
+    service = new MessageTemplateService();
+  });
+
+  it("returns recruiter templates for recruiters", async () => {
+    const result = await service.getTemplates(
+      recruiter.id,
+      UserRole.RECRUITER,
+      {
+        target_user_id: talent.id,
+      },
+    );
+
+    expect(result.templates).toHaveLength(3);
+    expect(result.templates.map((template) => template.id)).toEqual([
+      RECRUITER_TEMPLATE_IDS.INTRO_OUTREACH,
+      RECRUITER_TEMPLATE_IDS.SCHEDULE_INTERVIEW,
+      RECRUITER_TEMPLATE_IDS.AVAILABILITY_CHECK,
+    ]);
+    expect(result.templates[0].body).toContain("Hi Sharon");
+  });
+
+  it("returns talent templates for talents", async () => {
+    const result = await service.getTemplates(talent.id, UserRole.TALENT, {
+      target_user_id: recruiter.id,
+    });
+
+    expect(result.templates).toHaveLength(3);
+    expect(result.templates.map((template) => template.id)).toEqual([
+      TALENT_TEMPLATE_IDS.EXPRESS_INTEREST,
+      TALENT_TEMPLATE_IDS.FOLLOW_UP,
+      TALENT_TEMPLATE_IDS.SHARE_PORTFOLIO,
+    ]);
+    expect(result.templates[0].body).toContain("Hi Cameron");
+    expect(result.templates[2].body).toContain(
+      "https://portfolio.example/sharon",
+    );
+  });
+
+  it("filters templates by use case", async () => {
+    const result = await service.getTemplates(
+      recruiter.id,
+      UserRole.RECRUITER,
+      {
+        use_case: "intro_note",
+        target_user_id: talent.id,
+      },
+    );
+
+    expect(result.templates.length).toBeGreaterThan(0);
+    expect(
+      result.templates.every((template) =>
+        template.use_cases.includes("intro_note"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns no talent intro templates because intro notes are recruiter-led", async () => {
+    const result = await service.getTemplates(talent.id, UserRole.TALENT, {
+      use_case: "intro_note",
+      target_user_id: recruiter.id,
+    });
+
+    expect(result.templates).toHaveLength(0);
+  });
+
+  it("keeps template IDs unique across all role-based templates", async () => {
+    const recruiterTemplates = await service.getTemplates(
+      recruiter.id,
+      UserRole.RECRUITER,
+      {
+        target_user_id: talent.id,
+      },
+    );
+    const talentTemplates = await service.getTemplates(
+      talent.id,
+      UserRole.TALENT,
+      {
+        target_user_id: recruiter.id,
+      },
+    );
+    const allTemplateIds = [
+      ...recruiterTemplates.templates.map((template) => template.id),
+      ...talentTemplates.templates.map((template) => template.id),
+    ];
+
+    expect(new Set(allTemplateIds).size).toBe(allTemplateIds.length);
+  });
+
+  it("falls back to safe defaults when dynamic records are missing", async () => {
+    const result = await service.getTemplates(
+      "99999999-9999-4999-8999-999999999999",
+      UserRole.TALENT,
+      {
+        target_user_id: "99999999-9999-4999-8999-999999999999",
+      },
+    );
+
+    expect(result.templates[0].body).toContain("Hi there");
+    expect(result.templates[2].body).toContain("portfolio link");
+  });
+
+  it("uses role as recipient display value when first and last names are missing", async () => {
+    const result = await service.getTemplates(
+      recruiter.id,
+      UserRole.RECRUITER,
+      {
+        target_user_id: localRecruiterWithoutNames.id,
+      },
+    );
+
+    expect(result.templates[0].body).toContain("Hi Recruiter");
+  });
+
+  it("uses oauth recipient name when first and last names are available", async () => {
+    const result = await service.getTemplates(
+      recruiter.id,
+      UserRole.RECRUITER,
+      {
+        target_user_id: oauthTalentWithNames.id,
+      },
+    );
+
+    expect(result.templates[0].body).toContain("Hi Alex Morgan");
+  });
+});

--- a/src/__tests__/messaging/messageTemplate.service.test.ts
+++ b/src/__tests__/messaging/messageTemplate.service.test.ts
@@ -1,0 +1,161 @@
+import AppDataSource from "@src/datasource";
+import { UserProvider, UserRole } from "@src/entities/user.entity";
+import {
+  MessageTemplateService,
+  RECRUITER_TEMPLATE_IDS,
+  TALENT_TEMPLATE_IDS,
+} from "@src/messaging/services/messageTemplate.service";
+
+jest.mock("@src/datasource", () => ({
+  __esModule: true,
+  default: {
+    getRepository: jest.fn(),
+  },
+}));
+
+const mockUserRepo = {
+  findOne: jest.fn(),
+};
+
+const recruiter = {
+  id: "11111111-1111-4111-8111-111111111111",
+  first_name: "Cameron",
+  talent_profile: null,
+};
+
+const talent = {
+  id: "22222222-2222-4222-8222-222222222222",
+  first_name: "Sharon",
+  talent_profile: { job_title: "frontend development" },
+};
+
+const localRecruiterWithoutNames = {
+  id: "33333333-3333-4333-8333-333333333333",
+  first_name: null,
+  last_name: null,
+  provider: UserProvider.LOCAL,
+  role: UserRole.RECRUITER,
+  talent_profile: null,
+};
+
+const oauthTalentWithNames = {
+  id: "44444444-4444-4444-8444-444444444444",
+  first_name: "Alex",
+  last_name: "Morgan",
+  provider: UserProvider.GOOGLE,
+  role: UserRole.TALENT,
+  talent_profile: null,
+};
+
+describe("MessageTemplateService", () => {
+  let service: MessageTemplateService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (AppDataSource.getRepository as jest.Mock).mockReturnValue(mockUserRepo);
+    mockUserRepo.findOne.mockImplementation(({ where }) => {
+      if (where.id === recruiter.id) return Promise.resolve(recruiter);
+      if (where.id === talent.id) return Promise.resolve(talent);
+      if (where.id === localRecruiterWithoutNames.id) {
+        return Promise.resolve(localRecruiterWithoutNames);
+      }
+      if (where.id === oauthTalentWithNames.id) {
+        return Promise.resolve(oauthTalentWithNames);
+      }
+      return Promise.resolve(null);
+    });
+
+    service = new MessageTemplateService();
+  });
+
+  it("returns recruiter templates for recruiters", async () => {
+    const result = await service.getTemplates(UserRole.RECRUITER, {
+      target_user_id: talent.id,
+    });
+
+    expect(result.templates).toHaveLength(3);
+    expect(result.templates.map((template) => template.id)).toEqual([
+      RECRUITER_TEMPLATE_IDS.INTRO_OUTREACH,
+      RECRUITER_TEMPLATE_IDS.SCHEDULE_INTERVIEW,
+      RECRUITER_TEMPLATE_IDS.AVAILABILITY_CHECK,
+    ]);
+    expect(result.templates[0].body).toContain("Hi Sharon");
+  });
+
+  it("returns talent templates for talents", async () => {
+    const result = await service.getTemplates(UserRole.TALENT, {
+      target_user_id: recruiter.id,
+    });
+
+    expect(result.templates).toHaveLength(3);
+    expect(result.templates.map((template) => template.id)).toEqual([
+      TALENT_TEMPLATE_IDS.EXPRESS_INTEREST,
+      TALENT_TEMPLATE_IDS.FOLLOW_UP,
+      TALENT_TEMPLATE_IDS.SHARE_PORTFOLIO,
+    ]);
+    expect(result.templates[0].body).toContain("Hi Cameron");
+  });
+
+  it("filters templates by use case", async () => {
+    const result = await service.getTemplates(UserRole.RECRUITER, {
+      use_case: "intro_note",
+      target_user_id: talent.id,
+    });
+
+    expect(result.templates.length).toBeGreaterThan(0);
+    expect(
+      result.templates.every((template) =>
+        template.use_cases.includes("intro_note"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns no talent intro templates because intro notes are recruiter-led", async () => {
+    const result = await service.getTemplates(UserRole.TALENT, {
+      use_case: "intro_note",
+      target_user_id: recruiter.id,
+    });
+
+    expect(result.templates).toHaveLength(0);
+  });
+
+  it("keeps template IDs unique across all role-based templates", async () => {
+    const recruiterTemplates = await service.getTemplates(UserRole.RECRUITER, {
+      target_user_id: talent.id,
+    });
+    const talentTemplates = await service.getTemplates(UserRole.TALENT, {
+      target_user_id: recruiter.id,
+    });
+    const allTemplateIds = [
+      ...recruiterTemplates.templates.map((template) => template.id),
+      ...talentTemplates.templates.map((template) => template.id),
+    ];
+
+    expect(new Set(allTemplateIds).size).toBe(allTemplateIds.length);
+  });
+
+  it("falls back to safe defaults when dynamic records are missing", async () => {
+    const result = await service.getTemplates(UserRole.TALENT, {
+      target_user_id: "99999999-9999-4999-8999-999999999999",
+    });
+
+    expect(result.templates[0].body).toContain("Hi there");
+  });
+
+  it("uses role as recipient display value when first and last names are missing", async () => {
+    const result = await service.getTemplates(UserRole.RECRUITER, {
+      target_user_id: localRecruiterWithoutNames.id,
+    });
+
+    expect(result.templates[0].body).toContain("Hi Recruiter");
+  });
+
+  it("uses oauth recipient name when first and last names are available", async () => {
+    const result = await service.getTemplates(UserRole.RECRUITER, {
+      target_user_id: oauthTalentWithNames.id,
+    });
+
+    expect(result.templates[0].body).toContain("Hi Alex Morgan");
+  });
+});

--- a/src/docs/messaging.docs.ts
+++ b/src/docs/messaging.docs.ts
@@ -99,6 +99,14 @@
  *           type: string
  *           format: date-time
  *           nullable: true
+ *         latest_message_seen_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         latest_message_seen_status:
+ *           type: string
+ *           enum: [seen, unseen, no_messages]
+ *           example: "seen"
  *         created_at:
  *           type: string
  *           format: date-time
@@ -146,6 +154,23 @@
  *               allOf:
  *                 - $ref: '#/components/schemas/Message'
  *               nullable: true
+ *     MessageTemplate:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           example: "intro-product-fit"
+ *         title:
+ *           type: string
+ *           example: "Product Fit Intro"
+ *         body:
+ *           type: string
+ *           example: "Hi {{first_name}}, I came across your profile..."
+ *         use_cases:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum: [intro_note, active_message_compose]
  */
 
 export const getConversationInbox = `
@@ -316,6 +341,56 @@ export const getConversationMessages = `
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const markConversationThreadSeen = `
+  /**
+   * @swagger
+   * /api/v1/messages/threads/{threadId}/seen:
+   *   patch:
+   *     summary: Mark a conversation thread as seen
+   *     tags: [Messaging]
+   *     description: Marks the thread as seen for the authenticated participant and returns updated latest-message seen timestamp and status.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: threadId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               seen_at:
+   *                 type: string
+   *                 format: date-time
+   *                 description: Optional explicit seen timestamp. Defaults to current time.
+   *     responses:
+   *       200:
+   *         description: Conversation thread marked as seen
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Conversation thread marked as seen"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     thread:
+   *                       $ref: '#/components/schemas/ConversationThread'
    */
 `;
 
@@ -823,5 +898,53 @@ export const getOutgoingMessageRequests = `
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/ErrorResponse'
+   */
+`;
+
+export const getMessageTemplates = `
+  /**
+   * @swagger
+   * /api/v1/messages/templates:
+   *   get:
+  *     summary: Fetch fixed role-based message templates
+   *     tags: [Messaging]
+  *     description: Returns templates based on the authenticated role. Recruiters receive templates for messaging talent (including intro outreach), while talents receive templates for messaging recruiters in active conversation compose.
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: use_case
+   *         schema:
+   *           type: string
+   *           enum: [intro_note, active_message_compose]
+   *         description: Optional filter by where the template is intended to be used.
+  *       - in: query
+  *         name: target_user_id
+  *         required: true
+  *         schema:
+  *           type: string
+  *           format: uuid
+  *         description: Recipient user ID used to personalize template greeting.
+   *     responses:
+   *       200:
+   *         description: Message templates fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Message templates fetched successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     templates:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/MessageTemplate'
    */
 `;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -65,6 +65,8 @@ export interface MessageRequestUserSummary {
   role: UserRole | null;
 }
 
+export type LatestMessageSeenStatus = "seen" | "unseen" | "no_messages";
+
 export interface MessageRequestSummary {
   id: string;
   intro_note: string | null;
@@ -81,6 +83,8 @@ export interface ConversationThreadSummary {
   recruiter_last_seen_at: Date | null;
   talent_last_seen_at: Date | null;
   latest_message_at: Date | null;
+  latest_message_seen_at: Date | null;
+  latest_message_seen_status: LatestMessageSeenStatus;
   created_at: Date;
   updated_at: Date;
   accepted_request_id: string | null;
@@ -138,6 +142,17 @@ export interface PaginatedMessageSummary {
 export interface SentConversationMessageSummary {
   thread: ConversationThreadSummary;
   message: MessageSummary;
+}
+
+export interface MessageTemplateSummary {
+  id: string;
+  title: string;
+  body: string;
+  use_cases: string[];
+}
+
+export interface MessageTemplateLibrarySummary {
+  templates: MessageTemplateSummary[];
 }
 
 export interface TalentSearchResult {

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -3,13 +3,17 @@ import { Request, Response } from "express";
 import {
   ListConversationMessagesDto,
   ListConversationThreadsDto,
+  MarkConversationThreadSeenDto,
 } from "./schemas/conversation.schema";
 import { ListMessageRequestsDto } from "./schemas/messageRequest.schema";
+import { ListMessageTemplatesDto } from "./schemas/template.schema";
 import { ConversationService } from "./services/conversation.service";
 import { MessageRequestService } from "./services/messageRequest.service";
+import { MessageTemplateService } from "./services/messageTemplate.service";
 
 const messageRequestService = new MessageRequestService();
 const conversationService = new ConversationService();
+const messageTemplateService = new MessageTemplateService();
 
 export const acceptMessageRequest = asyncHandler(
   async (req: Request, res: Response) => {
@@ -114,6 +118,38 @@ export const getOutgoingMessageRequests = asyncHandler(
       status: "success",
       message: "Outgoing message requests fetched successfully",
       data: result,
+    });
+  },
+);
+
+export const getMessageTemplates = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await messageTemplateService.getTemplates(
+      req.user.id,
+      req.user.role,
+      req.query as ListMessageTemplatesDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Message templates fetched successfully",
+      data: result,
+    });
+  },
+);
+
+export const markConversationThreadSeen = asyncHandler(
+  async (req: Request, res: Response) => {
+    const thread = await conversationService.markThreadAsSeen(
+      req.user.id,
+      req.params.threadId,
+      req.body as MarkConversationThreadSeenDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Conversation thread marked as seen",
+      data: { thread },
     });
   },
 );

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -3,13 +3,17 @@ import { Request, Response } from "express";
 import {
   ListConversationMessagesDto,
   ListConversationThreadsDto,
+  MarkConversationThreadSeenDto,
 } from "./schemas/conversation.schema";
 import { ListMessageRequestsDto } from "./schemas/messageRequest.schema";
+import { ListMessageTemplatesDto } from "./schemas/template.schema";
 import { ConversationService } from "./services/conversation.service";
 import { MessageRequestService } from "./services/messageRequest.service";
+import { MessageTemplateService } from "./services/messageTemplate.service";
 
 const messageRequestService = new MessageRequestService();
 const conversationService = new ConversationService();
+const messageTemplateService = new MessageTemplateService();
 
 export const acceptMessageRequest = asyncHandler(
   async (req: Request, res: Response) => {
@@ -114,6 +118,37 @@ export const getOutgoingMessageRequests = asyncHandler(
       status: "success",
       message: "Outgoing message requests fetched successfully",
       data: result,
+    });
+  },
+);
+
+export const getMessageTemplates = asyncHandler(
+  async (req: Request, res: Response) => {
+    const result = await messageTemplateService.getTemplates(
+      req.user.role,
+      req.query as ListMessageTemplatesDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Message templates fetched successfully",
+      data: result,
+    });
+  },
+);
+
+export const markConversationThreadSeen = asyncHandler(
+  async (req: Request, res: Response) => {
+    const thread = await conversationService.markThreadAsSeen(
+      req.user.id,
+      req.params.threadId,
+      req.body as MarkConversationThreadSeenDto,
+    );
+
+    res.status(200).json({
+      status: "success",
+      message: "Conversation thread marked as seen",
+      data: { thread },
     });
   },
 );

--- a/src/messaging/messaging.route.ts
+++ b/src/messaging/messaging.route.ts
@@ -10,13 +10,16 @@ import {
   getConversationInbox,
   getConversationMessages,
   getIncomingMessageRequests,
+  getMessageTemplates,
   getOutgoingMessageRequests,
+  markConversationThreadSeen,
   sendConversationMessage,
 } from "./messaging.controller";
 import {
   conversationThreadParamsSchema,
   listConversationMessagesSchema,
   listConversationThreadsSchema,
+  markConversationThreadSeenSchema,
   sendConversationMessageSchema,
 } from "./schemas/conversation.schema";
 import {
@@ -24,6 +27,7 @@ import {
   listMessageRequestsSchema,
   messageRequestParamsSchema,
 } from "./schemas/messageRequest.schema";
+import { listMessageTemplatesSchema } from "./schemas/template.schema";
 
 const router = Router();
 
@@ -42,6 +46,14 @@ router.get(
   validateData(conversationThreadParamsSchema, ["params"]),
   validateData(listConversationMessagesSchema, ["query"]),
   getConversationMessages,
+);
+
+router.patch(
+  "/threads/:threadId/seen",
+  checkRole([UserRole.RECRUITER, UserRole.TALENT]),
+  validateData(conversationThreadParamsSchema, ["params"]),
+  validateData(markConversationThreadSeenSchema),
+  markConversationThreadSeen,
 );
 
 router.post(
@@ -71,6 +83,13 @@ router.get(
   checkRole(UserRole.RECRUITER),
   validateData(listMessageRequestsSchema, ["query"]),
   getOutgoingMessageRequests,
+);
+
+router.get(
+  "/templates",
+  checkRole([UserRole.RECRUITER, UserRole.TALENT]),
+  validateData(listMessageTemplatesSchema, ["query"]),
+  getMessageTemplates,
 );
 
 router.patch(

--- a/src/messaging/schemas/conversation.schema.ts
+++ b/src/messaging/schemas/conversation.schema.ts
@@ -4,6 +4,10 @@ export const conversationThreadParamsSchema = z.object({
   threadId: z.string().uuid(),
 });
 
+export const markConversationThreadSeenSchema = z.object({
+  seen_at: z.coerce.date().optional(),
+});
+
 export const listConversationThreadsSchema = z.object({
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20),
@@ -28,4 +32,8 @@ export type ListConversationMessagesDto = z.infer<
 
 export type SendConversationMessageDto = z.infer<
   typeof sendConversationMessageSchema
+>;
+
+export type MarkConversationThreadSeenDto = z.infer<
+  typeof markConversationThreadSeenSchema
 >;

--- a/src/messaging/schemas/template.schema.ts
+++ b/src/messaging/schemas/template.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const listMessageTemplatesSchema = z.object({
+  use_case: z.enum(["intro_note", "active_message_compose"]).optional(),
+  target_user_id: z.string().uuid(),
+});
+
+export type ListMessageTemplatesDto = z.infer<
+  typeof listMessageTemplatesSchema
+>;

--- a/src/messaging/services/conversation.service.ts
+++ b/src/messaging/services/conversation.service.ts
@@ -17,6 +17,7 @@ import {
 import {
   ListConversationMessagesDto,
   ListConversationThreadsDto,
+  MarkConversationThreadSeenDto,
   SendConversationMessageDto,
 } from "../schemas/conversation.schema";
 
@@ -112,12 +113,49 @@ export class ConversationService {
       const savedMessage = await messageRepo.save(message);
 
       thread.latest_message_at = savedMessage.created_at || new Date();
+      if (thread.recruiter.id === userId) {
+        thread.recruiter_last_seen_at = thread.latest_message_at;
+      } else {
+        thread.talent_last_seen_at = thread.latest_message_at;
+      }
       const savedThread = await threadRepo.save(thread);
 
       return {
-        thread: this.formatConversationThread(savedThread),
+        thread: this.formatConversationThread(savedThread, userId),
         message: this.formatMessage(savedMessage),
       };
+    });
+  }
+
+  async markThreadAsSeen(
+    userId: string,
+    threadId: string,
+    payload: MarkConversationThreadSeenDto,
+  ): Promise<ConversationThreadSummary> {
+    return AppDataSource.manager.transaction(async (manager) => {
+      const threadRepo = manager.getRepository(ConversationThreadEntity);
+      const thread = await threadRepo.findOne({
+        where: { id: threadId },
+        relations: ["recruiter", "talent", "accepted_request"],
+      });
+
+      this.assertThreadIsAccessibleAndActive(thread, userId);
+
+      const seenAt = payload.seen_at ?? new Date();
+      if (thread.recruiter.id === userId) {
+        thread.recruiter_last_seen_at = this.getLaterDate(
+          thread.recruiter_last_seen_at,
+          seenAt,
+        );
+      } else {
+        thread.talent_last_seen_at = this.getLaterDate(
+          thread.talent_last_seen_at,
+          seenAt,
+        );
+      }
+
+      const savedThread = await threadRepo.save(thread);
+      return this.formatConversationThread(savedThread, userId);
     });
   }
 
@@ -163,7 +201,7 @@ export class ConversationService {
     latestMessage: MessageEntity | null,
   ): ConversationInboxItemSummary {
     return {
-      ...this.formatConversationThread(thread),
+      ...this.formatConversationThread(thread, userId),
       conversation_partner: this.formatUser(
         thread.recruiter.id === userId ? thread.talent : thread.recruiter,
       ),
@@ -173,12 +211,23 @@ export class ConversationService {
 
   private formatConversationThread(
     thread: ConversationThreadEntity,
+    viewerUserId?: string,
   ): ConversationThreadSummary {
+    const latestMessageSeenAt = this.resolveLatestMessageSeenAt(
+      thread,
+      viewerUserId,
+    );
+
     return {
       id: thread.id,
       recruiter_last_seen_at: thread.recruiter_last_seen_at,
       talent_last_seen_at: thread.talent_last_seen_at,
       latest_message_at: thread.latest_message_at,
+      latest_message_seen_at: latestMessageSeenAt,
+      latest_message_seen_status: this.resolveLatestMessageSeenStatus(
+        thread.latest_message_at,
+        latestMessageSeenAt,
+      ),
       created_at: thread.created_at,
       updated_at: thread.updated_at,
       accepted_request_id: thread.accepted_request?.id || null,
@@ -231,5 +280,51 @@ export class ConversationService {
       hasNextPage: page * limit < total,
       hasPreviousPage: page > 1,
     };
+  }
+
+  private resolveLatestMessageSeenAt(
+    thread: ConversationThreadEntity,
+    viewerUserId?: string,
+  ): Date | null {
+    if (!viewerUserId) {
+      return null;
+    }
+
+    if (thread.recruiter.id === viewerUserId) {
+      return thread.recruiter_last_seen_at;
+    }
+
+    if (thread.talent.id === viewerUserId) {
+      return thread.talent_last_seen_at;
+    }
+
+    return null;
+  }
+
+  private resolveLatestMessageSeenStatus(
+    latestMessageAt: Date | null,
+    latestMessageSeenAt: Date | null,
+  ): "seen" | "unseen" | "no_messages" {
+    if (!latestMessageAt) {
+      return "no_messages";
+    }
+
+    if (!latestMessageSeenAt) {
+      return "unseen";
+    }
+
+    return latestMessageSeenAt.getTime() >= latestMessageAt.getTime()
+      ? "seen"
+      : "unseen";
+  }
+
+  private getLaterDate(currentDate: Date | null, candidateDate: Date): Date {
+    if (!currentDate) {
+      return candidateDate;
+    }
+
+    return currentDate.getTime() > candidateDate.getTime()
+      ? currentDate
+      : candidateDate;
   }
 }

--- a/src/messaging/services/messageRequest.service.ts
+++ b/src/messaging/services/messageRequest.service.ts
@@ -148,7 +148,7 @@ export class MessageRequestService {
 
       return {
         request: this.formatMessageRequest(savedRequest),
-        thread: this.formatConversationThread(thread),
+        thread: this.formatConversationThread(thread, talentId),
         initial_message: initialMessage
           ? this.formatMessage(initialMessage)
           : null,
@@ -390,12 +390,23 @@ export class MessageRequestService {
 
   private formatConversationThread(
     thread: ConversationThreadEntity,
+    viewerUserId?: string,
   ): ConversationThreadSummary {
+    const latestMessageSeenAt = this.resolveLatestMessageSeenAt(
+      thread,
+      viewerUserId,
+    );
+
     return {
       id: thread.id,
       recruiter_last_seen_at: thread.recruiter_last_seen_at,
       talent_last_seen_at: thread.talent_last_seen_at,
       latest_message_at: thread.latest_message_at,
+      latest_message_seen_at: latestMessageSeenAt,
+      latest_message_seen_status: this.resolveLatestMessageSeenStatus(
+        thread.latest_message_at,
+        latestMessageSeenAt,
+      ),
       created_at: thread.created_at,
       updated_at: thread.updated_at,
       accepted_request_id: thread.accepted_request?.id || null,
@@ -423,5 +434,41 @@ export class MessageRequestService {
       avatar: user.avatar,
       role: user.role,
     };
+  }
+
+  private resolveLatestMessageSeenAt(
+    thread: ConversationThreadEntity,
+    viewerUserId?: string,
+  ): Date | null {
+    if (!viewerUserId) {
+      return null;
+    }
+
+    if (thread.recruiter.id === viewerUserId) {
+      return thread.recruiter_last_seen_at;
+    }
+
+    if (thread.talent.id === viewerUserId) {
+      return thread.talent_last_seen_at;
+    }
+
+    return null;
+  }
+
+  private resolveLatestMessageSeenStatus(
+    latestMessageAt: Date | null,
+    latestMessageSeenAt: Date | null,
+  ): "seen" | "unseen" | "no_messages" {
+    if (!latestMessageAt) {
+      return "no_messages";
+    }
+
+    if (!latestMessageSeenAt) {
+      return "unseen";
+    }
+
+    return latestMessageSeenAt.getTime() >= latestMessageAt.getTime()
+      ? "seen"
+      : "unseen";
   }
 }

--- a/src/messaging/services/messageTemplate.service.ts
+++ b/src/messaging/services/messageTemplate.service.ts
@@ -1,0 +1,147 @@
+import AppDataSource from "@src/datasource";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import {
+  MessageTemplateLibrarySummary,
+  MessageTemplateSummary,
+} from "@src/interfaces";
+import { ListMessageTemplatesDto } from "../schemas/template.schema";
+
+const TEMPLATE_TOKEN_REGEX = /{{\s*([a-zA-Z0-9_]+)\s*}}/g;
+
+export const RECRUITER_TEMPLATE_IDS = {
+  INTRO_OUTREACH: "recruiter-intro-outreach",
+  SCHEDULE_INTERVIEW: "recruiter-schedule-interview",
+  AVAILABILITY_CHECK: "recruiter-availability-check",
+} as const;
+
+export const TALENT_TEMPLATE_IDS = {
+  EXPRESS_INTEREST: "talent-express-interest",
+  FOLLOW_UP: "talent-follow-up",
+  SHARE_PORTFOLIO: "talent-share-portfolio",
+} as const;
+
+const RECRUITER_MESSAGE_TEMPLATES: MessageTemplateSummary[] = [
+  {
+    id: RECRUITER_TEMPLATE_IDS.INTRO_OUTREACH,
+    title: "Intro Outreach",
+    body: "Hi {{first_name}}, your background caught my eye. Would you be open to a quick chat about a role I'm working on?",
+    use_cases: ["intro_note"],
+  },
+  {
+    id: RECRUITER_TEMPLATE_IDS.SCHEDULE_INTERVIEW,
+    title: "Schedule an Interview",
+    body: "Hi {{first_name}}, I'd love to schedule an interview to discuss a role that aligns with your experience. Are you available this week for a 30-minute call?",
+    use_cases: ["intro_note", "active_message_compose"],
+  },
+  {
+    id: RECRUITER_TEMPLATE_IDS.AVAILABILITY_CHECK,
+    title: "Ask About Availability",
+    body: "Hi {{first_name}}, I'm reaching out to check your availability for an upcoming project. Would you be open to sharing your current schedule and earliest start date?",
+    use_cases: ["active_message_compose"],
+  },
+];
+
+const TALENT_MESSAGE_TEMPLATES: MessageTemplateSummary[] = [
+  {
+    id: TALENT_TEMPLATE_IDS.EXPRESS_INTEREST,
+    title: "Express Interest",
+    body: "Hi {{first_name}}, I came across your job posting and I'm very interested. My experience aligns well with what you're looking for. I'd love to connect!",
+    use_cases: ["active_message_compose"],
+  },
+  {
+    id: TALENT_TEMPLATE_IDS.FOLLOW_UP,
+    title: "Follow up",
+    body: "Hi {{first_name}}, I wanted to follow up on my earlier application. I'm still very interested in the role and would love to hear if there are any updates on the hiring process.",
+    use_cases: ["active_message_compose"],
+  },
+  {
+    id: TALENT_TEMPLATE_IDS.SHARE_PORTFOLIO,
+    title: "Share Portfolio",
+    body: "Hi {{first_name}}, I'd like to share my portfolio with you showcasing relevant work I've done in this space. Here's a link to my latest projects: [portfolio link]. Let me know if you'd like to discuss further!",
+    use_cases: ["active_message_compose"],
+  },
+];
+
+export class MessageTemplateService {
+  private readonly userRepo = AppDataSource.getRepository(UserEntity);
+
+  async getTemplates(
+    role: UserRole,
+    query: ListMessageTemplatesDto,
+  ): Promise<MessageTemplateLibrarySummary> {
+    const roleTemplates =
+      role === UserRole.TALENT
+        ? TALENT_MESSAGE_TEMPLATES
+        : RECRUITER_MESSAGE_TEMPLATES;
+
+    const target = await this.userRepo.findOne({
+      where: { id: query.target_user_id },
+    });
+
+    const dynamicFields = this.buildDynamicFields(target);
+
+    const hydratedTemplates = roleTemplates.map((template) =>
+      this.hydrateTemplate(template, dynamicFields),
+    );
+
+    if (query.use_case === "intro_note") {
+      return {
+        templates: hydratedTemplates.filter((template) =>
+          template.use_cases.includes("intro_note"),
+        ),
+      };
+    }
+
+    if (query.use_case === "active_message_compose") {
+      return {
+        templates: hydratedTemplates.filter((template) =>
+          template.use_cases.includes("active_message_compose"),
+        ),
+      };
+    }
+
+    return { templates: hydratedTemplates };
+  }
+
+  private buildDynamicFields(
+    target: UserEntity | null,
+  ): Record<string, string> {
+    return {
+      first_name: this.resolveRecipientDisplayName(target),
+    };
+  }
+
+  private resolveRecipientDisplayName(target: UserEntity | null): string {
+    const firstName = target?.first_name?.trim();
+    const lastName = target?.last_name?.trim();
+
+    if (firstName) {
+      return `${firstName}`;
+    }
+
+    if (firstName || lastName) {
+      return firstName || lastName || "there";
+    }
+
+    if (target?.role) {
+      return target.role === UserRole.RECRUITER ? "Recruiter" : "Talent";
+    }
+
+    return "there";
+  }
+
+  private hydrateTemplate(
+    template: MessageTemplateSummary,
+    dynamicFields: Record<string, string>,
+  ): MessageTemplateSummary {
+    const body = template.body.replace(TEMPLATE_TOKEN_REGEX, (_, token) => {
+      const value = dynamicFields[token];
+      return typeof value === "string" ? value : `{{${token}}}`;
+    });
+
+    return {
+      ...template,
+      body,
+    };
+  }
+}

--- a/src/messaging/services/messageTemplate.service.ts
+++ b/src/messaging/services/messageTemplate.service.ts
@@ -1,0 +1,157 @@
+import AppDataSource from "@src/datasource";
+import { UserEntity, UserRole } from "@src/entities/user.entity";
+import {
+  MessageTemplateLibrarySummary,
+  MessageTemplateSummary,
+} from "@src/interfaces";
+import { ListMessageTemplatesDto } from "../schemas/template.schema";
+
+const TEMPLATE_TOKEN_REGEX = /{{\s*([a-zA-Z0-9_]+)\s*}}/g;
+
+export const RECRUITER_TEMPLATE_IDS = {
+  INTRO_OUTREACH: "recruiter-intro-outreach",
+  SCHEDULE_INTERVIEW: "recruiter-schedule-interview",
+  AVAILABILITY_CHECK: "recruiter-availability-check",
+} as const;
+
+export const TALENT_TEMPLATE_IDS = {
+  EXPRESS_INTEREST: "talent-express-interest",
+  FOLLOW_UP: "talent-follow-up",
+  SHARE_PORTFOLIO: "talent-share-portfolio",
+} as const;
+
+const RECRUITER_MESSAGE_TEMPLATES: MessageTemplateSummary[] = [
+  {
+    id: RECRUITER_TEMPLATE_IDS.INTRO_OUTREACH,
+    title: "Intro Outreach",
+    body: "Hi {{first_name}}, your background caught my eye. Would you be open to a quick chat about a role I'm working on?",
+    use_cases: ["intro_note"],
+  },
+  {
+    id: RECRUITER_TEMPLATE_IDS.SCHEDULE_INTERVIEW,
+    title: "Schedule an Interview",
+    body: "Hi {{first_name}}, I'd love to schedule an interview to discuss a role that aligns with your experience. Are you available this week for a 30-minute call?",
+    use_cases: ["intro_note", "active_message_compose"],
+  },
+  {
+    id: RECRUITER_TEMPLATE_IDS.AVAILABILITY_CHECK,
+    title: "Ask About Availability",
+    body: "Hi {{first_name}}, I'm reaching out to check your availability for an upcoming project. Would you be open to sharing your current schedule and earliest start date?",
+    use_cases: ["active_message_compose"],
+  },
+];
+
+const TALENT_MESSAGE_TEMPLATES: MessageTemplateSummary[] = [
+  {
+    id: TALENT_TEMPLATE_IDS.EXPRESS_INTEREST,
+    title: "Express Interest",
+    body: "Hi {{first_name}}, I came across your job posting and I'm very interested. My experience aligns well with what you're looking for. I'd love to connect!",
+    use_cases: ["active_message_compose"],
+  },
+  {
+    id: TALENT_TEMPLATE_IDS.FOLLOW_UP,
+    title: "Follow up",
+    body: "Hi {{first_name}}, I wanted to follow up on my earlier application. I'm still very interested in the role and would love to hear if there are any updates on the hiring process.",
+    use_cases: ["active_message_compose"],
+  },
+  {
+    id: TALENT_TEMPLATE_IDS.SHARE_PORTFOLIO,
+    title: "Share Portfolio",
+    body: "Hi {{first_name}}, I'd like to share my portfolio with you showcasing relevant work I've done in this space. Here's a link to my latest projects: {{portfolio_url}}. Let me know if you'd like to discuss further!",
+    use_cases: ["active_message_compose"],
+  },
+];
+
+export class MessageTemplateService {
+  private readonly userRepo = AppDataSource.getRepository(UserEntity);
+
+  async getTemplates(
+    userId: string,
+    role: UserRole,
+    query: ListMessageTemplatesDto,
+  ): Promise<MessageTemplateLibrarySummary> {
+    const roleTemplates =
+      role === UserRole.TALENT
+        ? TALENT_MESSAGE_TEMPLATES
+        : RECRUITER_MESSAGE_TEMPLATES;
+
+    const [actor, target] = await Promise.all([
+      this.userRepo.findOne({
+        where: { id: userId },
+        relations: ["talent_profile"],
+      }),
+      this.userRepo.findOne({
+        where: { id: query.target_user_id },
+      }),
+    ]);
+
+    const dynamicFields = this.buildDynamicFields(actor, target);
+
+    const hydratedTemplates = roleTemplates.map((template) =>
+      this.hydrateTemplate(template, dynamicFields),
+    );
+
+    if (query.use_case === "intro_note") {
+      return {
+        templates: hydratedTemplates.filter((template) =>
+          template.use_cases.includes("intro_note"),
+        ),
+      };
+    }
+
+    if (query.use_case === "active_message_compose") {
+      return {
+        templates: hydratedTemplates.filter((template) =>
+          template.use_cases.includes("active_message_compose"),
+        ),
+      };
+    }
+
+    return { templates: hydratedTemplates };
+  }
+
+  private buildDynamicFields(
+    actor: UserEntity | null,
+    target: UserEntity | null,
+  ): Record<string, string> {
+    return {
+      first_name: this.resolveRecipientDisplayName(target),
+      portfolio_url:
+        actor?.talent_profile?.portfolio_url?.trim() || "portfolio link",
+    };
+  }
+
+  private resolveRecipientDisplayName(target: UserEntity | null): string {
+    const firstName = target?.first_name?.trim();
+    const lastName = target?.last_name?.trim();
+
+    if (firstName) {
+      return `${firstName}`;
+    }
+
+    if (firstName || lastName) {
+      return firstName || lastName || "there";
+    }
+
+    if (target?.role) {
+      return target.role === UserRole.RECRUITER ? "Recruiter" : "Talent";
+    }
+
+    return "there";
+  }
+
+  private hydrateTemplate(
+    template: MessageTemplateSummary,
+    dynamicFields: Record<string, string>,
+  ): MessageTemplateSummary {
+    const body = template.body.replace(TEMPLATE_TOKEN_REGEX, (_, token) => {
+      const value = dynamicFields[token];
+      return typeof value === "string" ? value : `{{${token}}}`;
+    });
+
+    return {
+      ...template,
+      body,
+    };
+  }
+}


### PR DESCRIPTION
- Add conversation read receipt support with thread seen updates and latest message seen status.
- Expose thread seen metadata in messaging responses for inbox and compose flows.
- Add role-based template library for recruiter and talent messaging use cases.
- Hydrate template greeting from target_user_id with first-name, role or there fallback.
- Require target_user_id on template fetch for deterministic personalization behavior.
- Add and update messaging service tests for seen status and template personalization.
- Update messaging API docs for new endpoints, fields, and template query requirements.